### PR TITLE
Format(De)Serializer

### DIFF
--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -1828,46 +1828,46 @@ Value Value::FormatDeserialize(FormatDeserializer &deserializer) {
 	new_value.is_null = false;
 	switch (type.InternalType()) {
 	case PhysicalType::BOOL:
-		new_value.value_.boolean = deserializer.ReadProperty<bool>("value");
+		new_value.value_.boolean = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::UINT8:
-		new_value.value_.utinyint = deserializer.ReadProperty<uint8_t>("value");
+		new_value.value_.utinyint = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::INT8:
-		new_value.value_.tinyint = deserializer.ReadProperty<int8_t>("value");
+		new_value.value_.tinyint = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::UINT16:
-		new_value.value_.usmallint = deserializer.ReadProperty<uint16_t>("value");
+		new_value.value_.usmallint = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::INT16:
-		new_value.value_.smallint = deserializer.ReadProperty<int16_t>("value");
+		new_value.value_.smallint = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::UINT32:
-		new_value.value_.uinteger = deserializer.ReadProperty<uint32_t>("value");
+		new_value.value_.uinteger = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::INT32:
-		new_value.value_.integer = deserializer.ReadProperty<int32_t>("value");
+		new_value.value_.integer = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::UINT64:
-		new_value.value_.ubigint = deserializer.ReadProperty<uint64_t>("value");
+		new_value.value_.ubigint = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::INT64:
-		new_value.value_.bigint = deserializer.ReadProperty<int64_t>("value");
+		new_value.value_.bigint = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::INT128:
-		new_value.value_.hugeint = deserializer.ReadProperty<hugeint_t>("value");
+		new_value.value_.hugeint = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::FLOAT:
-		new_value.value_.float_ = deserializer.ReadProperty<float>("value");
+		new_value.value_.float_ = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::DOUBLE:
-		new_value.value_.double_ = deserializer.ReadProperty<double>("value");
+		new_value.value_.double_ = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::INTERVAL:
-		new_value.value_.interval = deserializer.ReadProperty<interval_t>("value");
+		new_value.value_.interval = deserializer.ReadProperty("value");
 		break;
 	case PhysicalType::VARCHAR: {
-		auto str = deserializer.ReadProperty<string>("value");
+		string str = deserializer.ReadProperty("value");
 		if (type.id() == LogicalTypeId::BLOB) {
 			new_value.value_info_ = make_shared<StringValueInfo>(Blob::ToBlob(str));
 		} else {

--- a/src/include/duckdb/common/optional_unique_ptr.hpp
+++ b/src/include/duckdb/common/optional_unique_ptr.hpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/common/optional_unique_ptr.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/unique_ptr.hpp"
+
+namespace duckdb {
+
+template <typename T>
+class optional_unique_ptr {
+public:
+	using innerType = T;
+	optional_unique_ptr() : inner(nullptr) {
+	}
+	optional_unique_ptr(T *ptr) : inner(ptr) {
+	}
+	optional_unique_ptr(unique_ptr<T> &&ptr_p) : inner(std::move(ptr_p)) {
+	}
+	optional_unique_ptr(optional_unique_ptr<T> &&ptr_p) : inner(std::move(ptr_p.inner)) {
+	}
+	explicit operator unique_ptr<T> &&() {
+		return std::move(inner);
+	}
+	operator unique_ptr<T> &() {
+		return inner;
+	}
+	operator const unique_ptr<T> &() const {
+		return inner;
+	}
+	optional_unique_ptr &operator=(optional_unique_ptr &&r) {
+		inner = std::move(r.inner);
+		return *this;
+	}
+	T *get() {
+		return inner.get();
+	}
+	const T *get() const {
+		return inner.get();
+	}
+	operator bool() const {
+		return !!inner;
+	}
+	T &operator*() {
+		return *inner;
+	}
+	const T &operator*() const {
+		return *inner;
+	}
+	T *operator->() {
+		return inner.get();
+	}
+	const T *operator->() const {
+		return inner.get();
+	}
+	unique_ptr<T> inner;
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/common/serializer/format_serializer.hpp
+++ b/src/include/duckdb/common/serializer/format_serializer.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/common/field_writer.hpp"
 #include "duckdb/common/serializer.hpp"
 #include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/optional_unique_ptr.hpp"
 #include "duckdb/common/serializer/serialization_traits.hpp"
 #include "duckdb/common/types/interval.hpp"
 #include "duckdb/common/types/string_type.hpp"
@@ -86,6 +87,19 @@ protected:
 	template <typename T>
 	void WriteValue(const unique_ptr<T> &ptr) {
 		WriteValue(ptr.get());
+	}
+
+	// Unique Pointer Ref
+	template <typename T>
+	void WriteValue(const optional_unique_ptr<T> &ptr) {
+		if (!ptr.inner) {
+			OnOptionalBegin(false);
+			OnOptionalEnd(false);
+		} else {
+			OnOptionalBegin(true);
+			WriteValue(ptr.inner.get());
+			OnOptionalEnd(true);
+		}
 	}
 
 	// Pointer

--- a/src/include/duckdb/common/serializer/serialization_traits.hpp
+++ b/src/include/duckdb/common/serializer/serialization_traits.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <type_traits>
 #include "duckdb/common/vector.hpp"
+#include "duckdb/common/optional_unique_ptr.hpp"
 #include "duckdb/common/unordered_map.hpp"
 #include "duckdb/common/unordered_set.hpp"
 
@@ -67,6 +68,14 @@ struct is_unique_ptr : std::false_type {};
 
 template <typename T>
 struct is_unique_ptr<unique_ptr<T>> : std::true_type {
+	typedef T ELEMENT_TYPE;
+};
+
+template <typename T>
+struct is_optional_unique_ptr : std::false_type {};
+
+template <typename T>
+struct is_optional_unique_ptr<optional_unique_ptr<T>> : std::true_type {
 	typedef T ELEMENT_TYPE;
 };
 

--- a/src/include/duckdb/parser/expression/function_expression.hpp
+++ b/src/include/duckdb/parser/expression/function_expression.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/optional_unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/result_modifier.hpp"
@@ -42,7 +43,7 @@ public:
 	//! Whether or not the aggregate function is distinct, only used for aggregates
 	bool distinct;
 	//! Expression representing a filter, only used for aggregates
-	unique_ptr<ParsedExpression> filter;
+	optional_unique_ptr<ParsedExpression> filter;
 	//! Modifier representing an ORDER BY, only used for aggregates
 	unique_ptr<OrderModifier> order_bys;
 	//! whether this function should export its state or not
@@ -66,7 +67,7 @@ public:
 public:
 	template <class T, class BASE, class ORDER_MODIFIER = OrderModifier>
 	static string ToString(const T &entry, const string &schema, const string &function_name, bool is_operator = false,
-	                       bool distinct = false, BASE *filter = nullptr, ORDER_MODIFIER *order_bys = nullptr,
+	                       bool distinct = false, const BASE *filter = nullptr, ORDER_MODIFIER *order_bys = nullptr,
 	                       bool export_state = false, bool add_alias = false) {
 		if (is_operator) {
 			// built-in operator

--- a/src/include/duckdb/parser/expression/window_expression.hpp
+++ b/src/include/duckdb/parser/expression/window_expression.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "duckdb/common/optional_unique_ptr.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/query_node.hpp"
 
@@ -56,11 +57,11 @@ public:
 	WindowBoundary start = WindowBoundary::INVALID;
 	WindowBoundary end = WindowBoundary::INVALID;
 
-	unique_ptr<ParsedExpression> start_expr;
-	unique_ptr<ParsedExpression> end_expr;
+	optional_unique_ptr<ParsedExpression> start_expr;
+	optional_unique_ptr<ParsedExpression> end_expr;
 	//! Offset and default expressions for WINDOW_LEAD and WINDOW_LAG functions
-	unique_ptr<ParsedExpression> offset_expr;
-	unique_ptr<ParsedExpression> default_expr;
+	optional_unique_ptr<ParsedExpression> offset_expr;
+	optional_unique_ptr<ParsedExpression> default_expr;
 
 public:
 	bool IsWindow() const override {

--- a/src/parser/common_table_expression_info.cpp
+++ b/src/parser/common_table_expression_info.cpp
@@ -11,8 +11,8 @@ void CommonTableExpressionInfo::FormatSerialize(FormatSerializer &serializer) co
 
 unique_ptr<CommonTableExpressionInfo> CommonTableExpressionInfo::FormatDeserialize(FormatDeserializer &deserializer) {
 	auto result = make_uniq<CommonTableExpressionInfo>();
-	result->aliases = deserializer.ReadProperty<vector<string>>("aliases");
-	result->query = deserializer.ReadProperty<unique_ptr<SelectStatement>>("query");
+	result->aliases = deserializer.ReadProperty("aliases");
+	result->query = deserializer.ReadProperty("query");
 	return result;
 }
 

--- a/src/parser/expression/conjunction_expression.cpp
+++ b/src/parser/expression/conjunction_expression.cpp
@@ -76,7 +76,7 @@ void ConjunctionExpression::FormatSerialize(FormatSerializer &serializer) const 
 unique_ptr<ParsedExpression> ConjunctionExpression::FormatDeserialize(ExpressionType type,
                                                                       FormatDeserializer &deserializer) {
 	auto result = make_uniq<ConjunctionExpression>(type);
-	result->children = deserializer.ReadProperty<vector<unique_ptr<ParsedExpression>>>("children");
+	result->children = deserializer.ReadProperty("children");
 	return std::move(result);
 }
 

--- a/src/parser/expression/operator_expression.cpp
+++ b/src/parser/expression/operator_expression.cpp
@@ -66,7 +66,7 @@ void OperatorExpression::FormatSerialize(FormatSerializer &serializer) const {
 unique_ptr<ParsedExpression> OperatorExpression::FormatDeserialize(ExpressionType type,
                                                                    FormatDeserializer &deserializer) {
 	auto expression = make_uniq<OperatorExpression>(type);
-	expression->children = deserializer.ReadProperty<vector<unique_ptr<ParsedExpression>>>("children");
+	expression->children = deserializer.ReadProperty("children");
 	return std::move(expression);
 }
 

--- a/src/parser/expression/parameter_expression.cpp
+++ b/src/parser/expression/parameter_expression.cpp
@@ -52,7 +52,7 @@ void ParameterExpression::FormatSerialize(FormatSerializer &serializer) const {
 unique_ptr<ParsedExpression> ParameterExpression::FormatDeserialize(ExpressionType type,
                                                                     FormatDeserializer &deserializer) {
 	auto expression = make_uniq<ParameterExpression>();
-	expression->parameter_nr = deserializer.ReadProperty<idx_t>("parameter_nr");
+	expression->parameter_nr = deserializer.ReadProperty("parameter_nr");
 	return std::move(expression);
 }
 

--- a/src/parser/expression/window_expression.cpp
+++ b/src/parser/expression/window_expression.cpp
@@ -150,10 +150,10 @@ void WindowExpression::Serialize(FieldWriter &writer) const {
 	writer.WriteField<WindowBoundary>(start);
 	writer.WriteField<WindowBoundary>(end);
 
-	writer.WriteOptional(start_expr);
-	writer.WriteOptional(end_expr);
-	writer.WriteOptional(offset_expr);
-	writer.WriteOptional(default_expr);
+	writer.WriteOptional(start_expr.inner);
+	writer.WriteOptional(end_expr.inner);
+	writer.WriteOptional(offset_expr.inner);
+	writer.WriteOptional(default_expr.inner);
 	writer.WriteField<bool>(ignore_nulls);
 	writer.WriteOptional(filter_expr);
 	writer.WriteString(catalog);
@@ -168,10 +168,10 @@ void WindowExpression::FormatSerialize(FormatSerializer &serializer) const {
 	serializer.WriteProperty("orders", orders);
 	serializer.WriteProperty("start", start);
 	serializer.WriteProperty("end", end);
-	serializer.WriteOptionalProperty("start_expr", start_expr);
-	serializer.WriteOptionalProperty("end_expr", end_expr);
-	serializer.WriteOptionalProperty("offset_expr", offset_expr);
-	serializer.WriteOptionalProperty("default_expr", default_expr);
+	serializer.WriteProperty("start_expr", start_expr);
+	serializer.WriteProperty("end_expr", end_expr);
+	serializer.WriteProperty("offset_expr", offset_expr);
+	serializer.WriteProperty("default_expr", default_expr);
 	serializer.WriteProperty("ignore_nulls", ignore_nulls);
 	serializer.WriteOptionalProperty("filter_expr", filter_expr);
 	serializer.WriteProperty("catalog", catalog);
@@ -188,10 +188,10 @@ unique_ptr<ParsedExpression> WindowExpression::FormatDeserialize(ExpressionType 
 	deserializer.ReadProperty("orders", expr->orders);
 	deserializer.ReadProperty("start", expr->start);
 	deserializer.ReadProperty("end", expr->end);
-	deserializer.ReadOptionalProperty("start_expr", expr->start_expr);
-	deserializer.ReadOptionalProperty("end_expr", expr->end_expr);
-	deserializer.ReadOptionalProperty("offset_expr", expr->offset_expr);
-	deserializer.ReadOptionalProperty("default_expr", expr->default_expr);
+	deserializer.ReadProperty("start_expr", expr->start_expr);
+	deserializer.ReadProperty("end_expr", expr->end_expr);
+	deserializer.ReadProperty("offset_expr", expr->offset_expr);
+	deserializer.ReadProperty("default_expr", expr->default_expr);
 	deserializer.ReadProperty("ignore_nulls", expr->ignore_nulls);
 	deserializer.ReadOptionalProperty("filter_expr", expr->filter_expr);
 	deserializer.ReadProperty("catalog", expr->catalog);

--- a/src/parser/tableref/subqueryref.cpp
+++ b/src/parser/tableref/subqueryref.cpp
@@ -44,7 +44,7 @@ void SubqueryRef::FormatSerialize(FormatSerializer &serializer) const {
 }
 
 unique_ptr<TableRef> SubqueryRef::FormatDeserialize(FormatDeserializer &deserializer) {
-	auto subquery = deserializer.ReadProperty<unique_ptr<SelectStatement>>("subquery");
+	unique_ptr<SelectStatement> subquery = deserializer.ReadProperty("subquery");
 	auto result = make_uniq<SubqueryRef>(std::move(subquery));
 	deserializer.ReadProperty("column_name_alias", result->column_name_alias);
 	return std::move(result);


### PR DESCRIPTION
This changes ReadProperty to generate a move-assignable dummy value like:
```
int x = x.ReadProperty("name");
/// equivalent to
int x = x.ReadProperty<int>("name");
```

Plus introduces a wrapper around unique_ptr that automatically serialize and deserialize using the OptionalProperty logic.
That should make possible to remove all usage of Write/ReadOptionalProperty, and only have Read/WriteProperty, with the serialization logic tied to the C++ type.