### PR TITLE
Extension docs

### DIFF
--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -12,6 +12,10 @@
 #define DUCKDB_EXTENSION_ICU_LINKED false
 #endif
 
+#ifndef DUCKDB_EXTENSION_EXCEL_LINKED
+#define DUCKDB_EXTENSION_EXCEL_LINKED false
+#endif
+
 #ifndef DUCKDB_EXTENSION_PARQUET_LINKED
 #define DUCKDB_EXTENSION_PARQUET_LINKED false
 #endif
@@ -52,6 +56,10 @@
 //		 these can be removed
 #if DUCKDB_EXTENSION_ICU_LINKED
 #include "icu_extension.hpp"
+#endif
+
+#if DUCKDB_EXTENSION_EXCEL_LINKED
+#include "excel_extension.hpp"
 #endif
 
 #if DUCKDB_EXTENSION_PARQUET_LINKED
@@ -101,7 +109,7 @@ static DefaultExtension internal_extensions[] = {
     {"httpfs", "Adds support for reading and writing files over a HTTP(S) connection", DUCKDB_EXTENSION_HTTPFS_LINKED},
     {"json", "Adds support for JSON operations", DUCKDB_EXTENSION_JSON_LINKED},
     {"jemalloc", "Overwrites system allocator with JEMalloc", DUCKDB_EXTENSION_JEMALLOC_LINKED},
-    {"autocomplete", "Add supports for autocomplete in the shell", DUCKDB_EXTENSION_AUTOCOMPLETE_LINKED},
+    {"autocomplete", "Adds support for autocomplete in the shell", DUCKDB_EXTENSION_AUTOCOMPLETE_LINKED},
     {"motherduck", "Enables motherduck integration with the system", false},
     {"sqlite_scanner", "Adds support for reading SQLite database files", false},
     {"postgres_scanner", "Adds support for reading from a Postgres database", false},

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -117,6 +117,9 @@ static DefaultExtension internal_extensions[] = {
     {"inet", "Adds support for IP-related data types and functions", false},
     {"spatial", "Geospatial extension that adds support for working with spatial data and functions", false},
     {"substrait", "Adds support for the Substrait integration", false},
+    {"aws", "Provides features that depend on the AWS SDK", false},
+    {"azure", "Adds a filesystem abstraction for Azure blob storage to DuckDB", false},
+    {"iceberg", "Adds support for Apache Iceberg", false},
     {nullptr, nullptr, false}};
 
 idx_t ExtensionHelper::DefaultExtensionCount() {

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -116,6 +116,7 @@ static DefaultExtension internal_extensions[] = {
     {"postgres_scanner", "Adds support for reading from a Postgres database", false},
     {"inet", "Adds support for IP-related data types and functions", false},
     {"spatial", "Geospatial extension that adds support for working with spatial data and functions", false},
+    {"substrait", "Adds support for the Substrait integration", false},
     {nullptr, nullptr, false}};
 
 idx_t ExtensionHelper::DefaultExtensionCount() {

--- a/src/main/extension/extension_helper.cpp
+++ b/src/main/extension/extension_helper.cpp
@@ -102,6 +102,7 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 static DefaultExtension internal_extensions[] = {
     {"icu", "Adds support for time zones and collations using the ICU library", DUCKDB_EXTENSION_ICU_LINKED},
+    {"excel", "Adds support for Excel-like format strings", DUCKDB_EXTENSION_EXCEL_LINKED},
     {"parquet", "Adds support for reading and writing parquet files", DUCKDB_EXTENSION_PARQUET_LINKED},
     {"tpch", "Adds TPC-H data generation and query support", DUCKDB_EXTENSION_TPCH_LINKED},
     {"tpcds", "Adds TPC-DS data generation and query support", DUCKDB_EXTENSION_TPCDS_LINKED},


### PR DESCRIPTION
This is a draft, idea is synchronising the output of `SELECT * FROM duckdb_extensions()`, the list in the docs here: https://duckdb.org/docs/extensions/overview#all-available-extensions, and the status of extension developement.

To be reviewed if something is missing