### PR TITLE
[Dev] Enable ThinLTO for CLI builds on Linux or OSX

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -50,6 +50,7 @@ jobs:
       BUILD_ODBC: 1
       DEBUG_STACKTRACE: 1
       FORCE_WARN_UNUSED: 1
+      LTO: 'thin'
 
     steps:
     - uses: actions/checkout@v3
@@ -123,6 +124,7 @@ jobs:
      FORCE_WARN_UNUSED: 1
      BUILD_ODBC: 1
      ODBC_CONFIG: ../../build/unixodbc/build/bin/odbc_config
+     LTO: 'thin'
 
    steps:
      - uses: actions/checkout@v3

--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -84,6 +84,7 @@ jobs:
       OSX_BUILD_UNIVERSAL: 1
       GEN: ninja
       ODBC_CONFIG: ../../build/unixodbc/build/bin/odbc_config
+      LTO: 'thin'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
LTO Makefile variable has been introduced earlier, should it be considered for CLI environments?

On my non-scientific benchmarks ThinLTO is around 5% faster AND 15-20% smaller on binary size. Only real downside is increase in linking time, and that's not really tested with DuckDB (altough it should be mature and it's been used for a decade by other complex projects, like browsers or DBMS).