### PR TITLE
Case insensitive extensions install & load

### DIFF
--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -69,7 +69,7 @@ public:
 	// Returns extension name, or empty string if not a replacement open path
 	static string ExtractExtensionPrefixFromPath(const string &path);
 
-	//! Apply any known extension aliases
+	//! Apply any known extension aliases, return the lowercase name
 	static string ApplyExtensionAlias(string extension_name);
 
 	static string GetExtensionName(const string &extension);

--- a/src/include/duckdb/main/extension_helper.hpp
+++ b/src/include/duckdb/main/extension_helper.hpp
@@ -70,7 +70,7 @@ public:
 	static string ExtractExtensionPrefixFromPath(const string &path);
 
 	//! Apply any known extension aliases, return the lowercase name
-	static string ApplyExtensionAlias(string extension_name);
+	static string ApplyExtensionAlias(const string &extension_name);
 
 	static string GetExtensionName(const string &extension);
 	static bool IsFullPath(const string &extension);

--- a/src/main/extension/extension_alias.cpp
+++ b/src/main/extension/extension_alias.cpp
@@ -31,7 +31,7 @@ string ExtensionHelper::ApplyExtensionAlias(string extension_name) {
 			return internal_aliases[index].extension;
 		}
 	}
-	return extension_name;
+	return lname;
 }
 
 } // namespace duckdb

--- a/src/main/extension/extension_alias.cpp
+++ b/src/main/extension/extension_alias.cpp
@@ -24,7 +24,7 @@ ExtensionAlias ExtensionHelper::GetExtensionAlias(idx_t index) {
 	return internal_aliases[index];
 }
 
-string ExtensionHelper::ApplyExtensionAlias(string extension_name) {
+string ExtensionHelper::ApplyExtensionAlias(const string &extension_name) {
 	auto lname = StringUtil::Lower(extension_name);
 	for (idx_t index = 0; internal_aliases[index].alias; index++) {
 		if (lname == internal_aliases[index].alias) {

--- a/src/main/extension/extension_install.cpp
+++ b/src/main/extension/extension_install.cpp
@@ -108,6 +108,7 @@ string ExtensionHelper::ExtensionDirectory(ClientContext &context) {
 }
 
 bool ExtensionHelper::CreateSuggestions(const string &extension_name, string &message) {
+	auto lowercase_extension_name = StringUtil::Lower(extension_name);
 	vector<string> candidates;
 	for (idx_t ext_count = ExtensionHelper::DefaultExtensionCount(), i = 0; i < ext_count; i++) {
 		candidates.emplace_back(ExtensionHelper::GetDefaultExtension(i).name);
@@ -115,10 +116,10 @@ bool ExtensionHelper::CreateSuggestions(const string &extension_name, string &me
 	for (idx_t ext_count = ExtensionHelper::ExtensionAliasCount(), i = 0; i < ext_count; i++) {
 		candidates.emplace_back(ExtensionHelper::GetExtensionAlias(i).alias);
 	}
-	auto closest_extensions = StringUtil::TopNLevenshtein(candidates, extension_name);
+	auto closest_extensions = StringUtil::TopNLevenshtein(candidates, lowercase_extension_name);
 	message = StringUtil::CandidatesMessage(closest_extensions, "Candidate extensions");
 	for (auto &closest : closest_extensions) {
-		if (closest == extension_name) {
+		if (closest == lowercase_extension_name) {
 			message = "Extension \"" + extension_name + "\" is an existing extension.\n";
 			return true;
 		}

--- a/src/main/extension/extension_load.cpp
+++ b/src/main/extension/extension_load.cpp
@@ -207,8 +207,10 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
 		throw IOException("Extension \"%s\" could not be loaded: %s", filename, GetDLError());
 	}
 
+	auto lowercase_extension_name = StringUtil::Lower(filebase);
+
 	ext_version_fun_t version_fun;
-	auto version_fun_name = filebase + "_version";
+	auto version_fun_name = lowercase_extension_name + "_version";
 
 	version_fun = LoadFunctionFromDLL<ext_version_fun_t>(lib_hdl, version_fun_name, filename);
 
@@ -235,7 +237,7 @@ bool ExtensionHelper::TryInitialLoad(DBConfig &config, FileSystem &fs, const str
 		                            extension_version, engine_version);
 	}
 
-	result.filebase = filebase;
+	result.filebase = lowercase_extension_name;
 	result.filename = filename;
 	result.lib_hdl = lib_hdl;
 	return true;

--- a/test/extension/install_extension.test_slow
+++ b/test/extension/install_extension.test_slow
@@ -35,6 +35,21 @@ LOAD 'loadable_extension_demo';
 # need to restart to unload extensions
 restart
 
+# this will succeed on MacOS due to case insensitive filesystem
+statement maybe
+FORCE INSTALL '__BUILD_DIRECTORY__/test/extension/loadable_extension_DEMO.duckdb_extension';
+----
+IO Error: Failed to read extension from
+
+statement ok
+FORCE INSTALL '__BUILD_DIRECTORY__/test/extension/loadable_extension_demo.duckdb_extension';
+
+statement ok
+LOAD 'Loadable_Extension_DEMO';
+
+# need to restart to unload extensions
+restart
+
 # can't find extension in non-default extension location
 statement ok
 SET extension_directory='__TEST_DIR__/extension_directory'


### PR DESCRIPTION
Make so that:
```sql
INSTALL spatial; LOAD spatial;
INSTALL SPATIAL; LOAD SPATIAL;
INSTALL SpAtiAL; LOAD SPAtial;
```
all behave the same (via normalising to lower case version).

When a file path is passed, file path casing is used unchanged, but lower case name is used to compose ${EXT_NAME}_version() and ${EXT_NAME}_init() function names and to register the extension internally.

This has been raised a few times by spatial/SPATIAL users.