### PR TITLE
[Dev] Avoid requiring expected error message on third_party tests

### DIFF
--- a/test/sqlite/sqllogic_parser.cpp
+++ b/test/sqlite/sqllogic_parser.cpp
@@ -87,10 +87,10 @@ vector<string> SQLLogicParser::ExtractExpectedResult() {
 	return result;
 }
 
-string SQLLogicParser::ExtractExpectedError(bool expect_ok) {
+string SQLLogicParser::ExtractExpectedError(bool expect_ok, bool original_sqlite_test) {
 	// check if there is an expected error at all
 	if (current_line >= lines.size() || lines[current_line] != "----") {
-		if (!expect_ok) {
+		if (!expect_ok && !original_sqlite_test) {
 			Fail("Failed to parse statement: statement error needs to have an expected error message");
 		}
 		return string();

--- a/test/sqlite/sqllogic_parser.hpp
+++ b/test/sqlite/sqllogic_parser.hpp
@@ -80,7 +80,7 @@ public:
 	vector<string> ExtractExpectedResult();
 
 	//! Extract the expected error (in case of statement error)
-	string ExtractExpectedError(bool expect_ok);
+	string ExtractExpectedError(bool expect_ok, bool original_sqlite_test);
 
 	//! Tokenize the current line
 	SQLLogicToken Tokenize();

--- a/test/sqlite/sqllogic_test_runner.cpp
+++ b/test/sqlite/sqllogic_test_runner.cpp
@@ -299,7 +299,7 @@ void SQLLogicTestRunner::ExecuteFile(string script) {
 				parser.Fail("Unexpected empty statement text");
 			}
 			command->expected_error =
-			    parser.ExtractExpectedError(command->expected_result == ExpectedResult::RESULT_SUCCESS);
+			    parser.ExtractExpectedError(command->expected_result == ExpectedResult::RESULT_SUCCESS, original_sqlite_test);
 
 			// perform any renames in the text
 			command->base_sql_query = ReplaceKeywords(std::move(statement_text));


### PR DESCRIPTION
Full run of unittest (`./build/release/test/unittest "*"`) is failing on missing error messages for sqllogic tests.
Same on CI for the nightly tests.

Changed suggested by @Mytherin, makes so that external tests are not required to have messages.
Detection is based on file_name starting with "third_party", it's probably not be super robust.
Proper solution would be passing it down from runTest invocation, I can do that if it make more sense.