### PR TITLE
Add ExtensionBuilder.yml

### DIFF
--- a/.github/workflows/ExtensionBuilder.yml
+++ b/.github/workflows/ExtensionBuilder.yml
@@ -1,0 +1,294 @@
+name: ExtensionBuilder
+on:
+    workflow_dispatch:
+
+jobs:
+    linux_amd64_gcc4:
+        name: Linux Extensions (linux_amd64_gcc4)
+        runs-on: ubuntu-latest
+        container: quay.io/pypa/manylinux2014_x86_64
+        env:
+            GEN: ninja
+
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+
+            - uses: ./.github/actions/manylinux_2014_setup
+              with:
+                  aws-cli: 1
+                  ninja-build: 1
+                  ccache: 1
+                  nodejs: 1
+                  ssh: 1
+                  python_alias: 1
+                  openssl: 1
+
+            - uses: ./.github/actions/build_extensions
+              with:
+                  vcpkg_target_triplet: x64-linux
+                  no_static_linking: 1
+                  run_tests: 0
+                  run_autoload_tests: 0
+                  treat_warn_as_error: 0
+                  ninja: 1
+
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: linux_amd64_gcc4
+                  path: |
+                      build/release/repository
+
+    windows_amd64:
+        # Builds extensions for windows_amd64
+        name: Windows Extensions (64-bit)
+        runs-on: windows-latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+
+            - name: Keep \n line endings
+              shell: bash
+              run: |
+                  git config --global core.autocrlf false
+                  git config --global core.eol lf
+
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.7"
+
+            - uses: ./.github/actions/build_extensions
+              with:
+                  vcpkg_target_triplet: x64-windows-static-md
+                  treat_warn_as_error: 0
+                  no_static_linking: 1
+                  run_tests: 0
+                  run_autoload_tests: 0
+
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: windows_amd64
+                  path: |
+                      build/release/repository
+
+    windows_amd64_rtools:
+        name: R Package Windows (Extesions)
+        runs-on: windows-latest
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.7"
+
+            - uses: r-lib/actions/setup-r@v2
+              with:
+                  r-version: "devel"
+                  update-rtools: true
+                  rtools-version: "42" # linker bug in 43 ^^
+
+            - name: Setup Ccache
+              uses: hendrikmuhs/ccache-action@main
+              with:
+                  key: ${{ github.job }}
+                  save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
+
+            - uses: ./.github/actions/build_extensions
+              with:
+                  duckdb_arch: windows_amd64_rtools
+                  vcpkg_target_triplet: x64-mingw-static
+                  treat_warn_as_error: 0
+                  override_cc: gcc
+                  override_cxx: g++
+                  vcpkg_build: 1
+                  no_static_linking: 1
+                  run_tests: 0
+                  run_autoload_tests: 0
+
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: windows_amd64_rtools
+                  path: |
+                      build/release/repository
+    osx_:
+        # Builds extensions for osx_arm64 and osx_amd64
+        name: OSX Extensions Release
+        runs-on: macos-latest
+        strategy:
+            matrix:
+                label: ["x86_64", "arm64"]
+                include:
+                    - label: x86_64
+                      osx_arch: x86_64
+                      duckdb_arch: osx_amd64
+                      vcpkg_triplet: x64-osx
+                      run_autoload_tests: 1
+                    - label: arm64
+                      osx_arch: arm64
+                      duckdb_arch: osx_arm64
+                      vcpkg_triplet: arm64-osx
+                      run_autoload_tests: 0
+
+        env:
+            VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
+            GEN: ninja
+            DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.7"
+
+            - name: Install Ninja and Pkg-config
+              run: brew install pkg-config ninja
+
+            - name: Setup Ccache
+              uses: hendrikmuhs/ccache-action@main
+              with:
+                  key: ${{ github.job }}-${{ matrix.label }}
+                  save: ${{ github.ref == 'refs/heads/main' || github.repository != 'duckdb/duckdb' }}
+            - uses: ./.github/actions/build_extensions
+              with:
+                  treat_warn_as_error: 0
+                  run_tests: 0
+                  osx_arch: ${{ matrix.osx_arch }}
+                  vcpkg_target_triplet: ${{ matrix.vcpkg_triplet }}
+                  duckdb_arch: ${{ matrix.duckdb_arch }}
+                  build_in_tree_extensions: 1
+                  build_out_of_tree_extensions: 1
+                  run_autoload_tests: 0
+                  ninja: 1
+
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: ${{ matrix.duckdb_arch }}
+                  path: |
+                      build/release/repository
+
+    # Linux extensions for builds that use C++11 ABI, currently these are all linux builds based on ubuntu >= 18 (e.g. NodeJS)
+    # note that the linux-release-64 is based on the manylinux-based extensions, which are built in .github/workflows/Python.yml
+    linux_amd64:
+        # Builds extensions for linux_amd64
+        name: Linux Extensions (x64)
+        runs-on: ubuntu-latest
+        container: ubuntu:18.04
+
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+
+            - uses: ./.github/actions/ubuntu_18_setup
+              with:
+                  vcpkg: 1
+                  openssl: 1
+                  ccache: 1
+
+            - uses: ./.github/actions/build_extensions
+              with:
+                  vcpkg_target_triplet: x64-linux
+                  deploy_as: linux_amd64
+                  treat_warn_as_error: 0
+                  run_autoload_tests: 0
+                  run_tests: 0
+                  ninja: 1
+
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: linux_amd64
+                  path: |
+                      build/release/repository
+
+    linux_arm64:
+        # Builds extensions for linux_arm64
+        name: Linux Extensions (aarch64)
+        runs-on: ubuntu-latest
+        container: ubuntu:18.04
+
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+
+            - uses: ./.github/actions/ubuntu_18_setup
+              with:
+                  vcpkg: 1
+                  openssl: 1
+                  aarch64_cross_compile: 1
+                  ccache: 1
+
+            - uses: ./.github/actions/build_extensions
+              with:
+                  vcpkg_target_triplet: arm64-linux
+                  duckdb_arch: linux_arm64
+                  treat_warn_as_error: 0
+                  aarch64_cross_compile: 1
+                  run_tests: 0 # Cannot run tests here due to cross-compiling
+                  run_autoload_tests: 0
+                  ninja: 1
+
+            - uses: actions/upload-artifact@v3
+              with:
+                  name: linux_arm64
+                  path: |
+                      build/release/repository
+
+    collector:
+       name: Collect extensions
+       runs-on: ubuntu-latest
+       needs:
+       - osx_
+       - windows_amd64
+       - windows_amd64_rtools
+       - linux_arm64
+       - linux_amd64
+       - linux_amd64_gcc4
+
+       steps:
+       - uses: actions/download-artifact@v3
+         with:
+           path: repository
+           name: linux_arm64
+
+       - uses: actions/download-artifact@v3
+         with:
+           path: repository
+           name: linux_amd64_gcc4
+
+       - uses: actions/download-artifact@v3
+         with:
+           path: repository
+           name: linux_amd64
+
+       - uses: actions/download-artifact@v3
+         with:
+           path: repository
+           name: windows_amd64
+
+       - uses: actions/download-artifact@v3
+         with:
+           path: repository
+           name: windows_amd64_rtools
+
+       - uses: actions/download-artifact@v3
+         with:
+           path: repository
+           name: osx_amd64
+
+       - uses: actions/download-artifact@v3
+         with:
+           path: repository
+           name: osx_arm64
+
+       - uses: actions/upload-artifact@v3
+         with:
+           path: repository
+           name: extensions


### PR DESCRIPTION
Idea is having a single workflow that (passing responsibility to .github/actions/build_extensions for the actual work) is able to build all relevant extensions.

Workflow currently is missing that:
* it does not sign extensions
* it does not upload extensions anywhere