### PR TITLE
DuckDB-Wasm's patch for single thread case

### DIFF
--- a/src/parallel/executor.cpp
+++ b/src/parallel/executor.cpp
@@ -466,6 +466,7 @@ void Executor::SignalTaskRescheduled(lock_guard<mutex> &) {
 }
 
 void Executor::WaitForTask() {
+#ifndef DUCKDB_NO_THREADS
 	static constexpr std::chrono::milliseconds WAIT_TIME = std::chrono::milliseconds(20);
 	std::unique_lock<mutex> l(executor_lock);
 	if (to_be_rescheduled_tasks.empty()) {
@@ -477,6 +478,7 @@ void Executor::WaitForTask() {
 	}
 
 	task_reschedule.wait_for(l, WAIT_TIME);
+#endif
 }
 
 void Executor::RescheduleTask(shared_ptr<Task> &task_p) {

--- a/src/parallel/task_scheduler.cpp
+++ b/src/parallel/task_scheduler.cpp
@@ -70,19 +70,16 @@ bool ConcurrentQueue::DequeueFromProducer(ProducerToken &token, shared_ptr<Task>
 #else
 struct ConcurrentQueue {
 	std::queue<shared_ptr<Task>> q;
-	mutex qlock;
 
 	void Enqueue(ProducerToken &token, shared_ptr<Task> task);
 	bool DequeueFromProducer(ProducerToken &token, shared_ptr<Task> &task);
 };
 
 void ConcurrentQueue::Enqueue(ProducerToken &token, shared_ptr<Task> task) {
-	lock_guard<mutex> lock(qlock);
 	q.push(std::move(task));
 }
 
 bool ConcurrentQueue::DequeueFromProducer(ProducerToken &token, shared_ptr<Task> &task) {
-	lock_guard<mutex> lock(qlock);
 	if (q.empty()) {
 		return false;
 	}


### PR DESCRIPTION
Note that none of this gets actually tested in regular multithreaded duckdb, so tests here are not really relevant.