### PR TITLE
Amend https://github.com/duckdb/duckdb/pull/15285 to make ClientContext optional

### DIFF
--- a/src/common/arrow/arrow_appender.cpp
+++ b/src/common/arrow/arrow_appender.cpp
@@ -40,8 +40,10 @@ void ArrowAppender::Append(DataChunk &input, const idx_t from, const idx_t to, c
 	for (idx_t i = 0; i < input.ColumnCount(); i++) {
 		if (root_data[i]->extension_data && root_data[i]->extension_data->duckdb_to_arrow) {
 			Vector input_data(root_data[i]->extension_data->GetInternalType());
-			root_data[i]->extension_data->duckdb_to_arrow(*options.client_context, input.data[i], input_data,
-			                                              input_size);
+			if (options.client_context) {
+				root_data[i]->extension_data->duckdb_to_arrow(*options.client_context, input.data[i], input_data,
+				                                              input_size);
+			}
 			root_data[i]->append_vector(*root_data[i], input_data, from, to, input_size);
 		} else {
 			root_data[i]->append_vector(*root_data[i], input.data[i], from, to, input_size);

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -59,10 +59,10 @@ void InitializeChild(ArrowSchema &child, DuckDBArrowSchemaHolder &root_holder, c
 }
 
 void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                    ClientProperties &options, ClientContext &context);
+                    ClientProperties &options, optional_ptr<ClientContext> context);
 
 void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                       ClientProperties &options, ClientContext &context) {
+                       ClientProperties &options, optional_ptr<ClientContext> context) {
 	child.format = "+m";
 	//! Map has one child which is a struct
 	child.n_children = 1;
@@ -78,18 +78,21 @@ void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child,
 }
 
 bool SetArrowExtension(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                       ClientContext &context) {
-	auto &config = DBConfig::GetConfig(context);
+                       optional_ptr<ClientContext> context) {
+	if (!context) {
+		return false;
+	}
+	auto &config = DBConfig::GetConfig(*context);
 	if (config.HasArrowExtension(type.id())) {
 		auto arrow_extension = config.GetArrowExtension(type.id());
-		arrow_extension.PopulateArrowSchema(root_holder, child, type, context, arrow_extension);
+		arrow_extension.PopulateArrowSchema(root_holder, child, type, *context, arrow_extension);
 		return true;
 	}
 	return false;
 }
 
 void SetArrowFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
-                    ClientProperties &options, ClientContext &context) {
+                    ClientProperties &options, optional_ptr<ClientContext> context) {
 	if (type.HasAlias()) {
 		// If it is a json type, we only export it as json if arrow_lossless_conversion = True
 		if (!(type.IsJSONType() && !options.arrow_lossless_conversion)) {
@@ -403,7 +406,7 @@ void ArrowConverter::ToArrowSchema(ArrowSchema *out_schema, const vector<Logical
 		root_holder->owned_column_names.push_back(AddName(names[col_idx]));
 		auto &child = root_holder->children[col_idx];
 		InitializeChild(child, *root_holder, names[col_idx]);
-		SetArrowFormat(*root_holder, child, types[col_idx], options, *options.client_context);
+		SetArrowFormat(*root_holder, child, types[col_idx], options, options.client_context);
 	}
 
 	// Release ownership to caller


### PR DESCRIPTION
This PR will likely NOT pass the extension side CI, but opening for feedback.

In duckdb/duckdb-wasm arrow is currently used without ClientContext not being there (note to me, double check).

In general I am not sure whether requiring ClientContext to being able to do Arrow operations do not introduces unnecessary complexity / interdependencies.


Question is: do we really need extensions-types in ALL cases? Or are we fine without.
And if so, why doing dereference without checks?