### PR TITLE
Shell: proposal to add `.mode llm`

### DIFF
--- a/tools/shell/include/shell_state.hpp
+++ b/tools/shell/include/shell_state.hpp
@@ -73,7 +73,8 @@ enum class RenderMode : uint32_t {
 	LATEX,     /* Latex tabular formatting */
 	TRASH,     /* Discard output */
 	JSONLINES, /* Output JSON Lines */
-	DUCKBOX    /* Unicode box drawing - using DuckDB's own renderer */
+	DUCKBOX,   /* Unicode box drawing - using DuckDB's own renderer */
+	LLM        /* LLM-friendly: pipe-separated, budget-paginated */
 };
 
 enum class PrintOutput { STDOUT, STDERR };
@@ -189,6 +190,14 @@ public:
 	size_t max_width = 0; /* The maximum number of characters to render horizontally in DuckBox mode */
 	//! The maximum number of rows to analyze in order to determine column widths in DuckBox mode
 	idx_t max_analyze_rows = 0;
+	//! LLM mode: byte budget before pagination (0 = unlimited)
+	idx_t llm_bytes_budget = 4000;
+	//! LLM mode: max chars per cell value before truncation (0 = no truncation)
+	idx_t llm_value_truncation = 72;
+	//! LLM mode: string to display for NULL values
+	string llm_null = "-";
+	//! SQL of the query currently being rendered (used by LLM renderer for OFFSET detection)
+	string current_query;
 	//! Decimal separator (if any)
 	char decimal_separator = '\0';
 	//! Thousand separator (if any)

--- a/tools/shell/shell.cpp
+++ b/tools/shell/shell.cpp
@@ -731,6 +731,8 @@ string ShellState::ModeToString(RenderMode mode) {
 		return "jsonlines";
 	case RenderMode::DUCKBOX:
 		return "duckbox";
+	case RenderMode::LLM:
+		return "llm";
 	}
 	return "invalid";
 }
@@ -1017,6 +1019,7 @@ SuccessState ShellState::ExecuteSQL(const string &zSql) {
 			if (UseDescribeRenderMode(*statement, describe_table_name)) {
 				cMode = RenderMode::DESCRIBE;
 			}
+			current_query = zStmtSql;
 
 			auto rc = ExecuteStatement(std::move(statement));
 			if (rc != SuccessState::SUCCESS) {
@@ -1594,7 +1597,9 @@ bool ShellState::SetOutputMode(const string &mode_name, const char *tbl_name) {
 		PrintF(PrintOutput::STDERR, "TABLE argument can only be used with .mode insert");
 		return false;
 	}
-	if (c2 == 'l' && n2 > 2 && strncmp(mode_str, "lines", n2) == 0) {
+	if (c2 == 'l' && strncmp(mode_str, "llm", n2) == 0) {
+		mode = RenderMode::LLM;
+	} else if (c2 == 'l' && n2 > 2 && strncmp(mode_str, "lines", n2) == 0) {
 		mode = RenderMode::LINE;
 		rowSeparator = SEP_Row;
 	} else if (c2 == 'c' && strncmp(mode_str, "columns", n2) == 0) {
@@ -1650,7 +1655,7 @@ bool ShellState::SetOutputMode(const string &mode_name, const char *tbl_name) {
 	} else {
 		PrintF(PrintOutput::STDERR, "Error: mode should be one of: "
 		                            "ascii box column csv duckbox html insert json jsonlines latex line "
-		                            "list markdown quote table tabs tcl trash \n");
+		                            "list llm markdown quote table tabs tcl trash \n");
 		return false;
 	}
 	cMode = mode;

--- a/tools/shell/shell_metadata_command.cpp
+++ b/tools/shell/shell_metadata_command.cpp
@@ -244,6 +244,32 @@ MetadataResult ToggleLog(ShellState &state, const vector<string> &args) {
 	return MetadataResult::SUCCESS;
 }
 
+MetadataResult SetLlmBytesBudget(ShellState &state, const vector<string> &args) {
+	if (args.size() > 2) {
+		return MetadataResult::PRINT_USAGE;
+	}
+	if (args.size() == 1) {
+		state.PrintF("current mode_llm_bytes_budget: %llu bytes (0 = unlimited)\n",
+		             (unsigned long long)state.llm_bytes_budget);
+		return MetadataResult::SUCCESS;
+	}
+	state.llm_bytes_budget = (idx_t)ShellState::StringToInt(args[1]);
+	return MetadataResult::SUCCESS;
+}
+
+MetadataResult SetLlmValueTruncation(ShellState &state, const vector<string> &args) {
+	if (args.size() > 2) {
+		return MetadataResult::PRINT_USAGE;
+	}
+	if (args.size() == 1) {
+		state.PrintF("current mode_llm_value_truncation: %llu chars (0 = no truncation)\n",
+		             (unsigned long long)state.llm_value_truncation);
+		return MetadataResult::SUCCESS;
+	}
+	state.llm_value_truncation = (idx_t)ShellState::StringToInt(args[1]);
+	return MetadataResult::SUCCESS;
+}
+
 MetadataResult SetMaxRows(ShellState &state, const vector<string> &args) {
 	if (args.size() > 3) {
 		return MetadataResult::PRINT_USAGE;
@@ -852,6 +878,10 @@ static const MetadataCommand metadata_commands[] = {
      "line\tOne value per line\n\tlist\tValues delimited by \"|\"\n\tmarkdown\tMarkdown table format\n\t"
      "quote\tEscape answers as for SQL\n\ttable\tASCII-art table\n\ttabs\tTab-separated values\n\ttcl\tTCL list "
      "elements\n\ttrash\tNo output"},
+    {"mode_llm_bytes_budget", 0, SetLlmBytesBudget, "BYTES",
+     "Byte budget before pagination in llm mode (default: 4000, 0 = unlimited)", 0, ""},
+    {"mode_llm_value_truncation", 0, SetLlmValueTruncation, "CHARS",
+     "Max characters per cell value in llm mode (default: 72, 0 = no truncation)", 0, ""},
 #ifdef HAVE_LINENOISE
     {"multiline", 1, ToggleMultiLine, "", "Sets the render mode to multi-line", 0, ""},
 #endif

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1570,7 +1570,7 @@ public:
 	}
 
 	bool RequireMaterializedResult() const override {
-		return true;
+		return false;
 	}
 
 	bool ShouldUsePager(RenderingQueryResult &, PagerMode) override {
@@ -1578,8 +1578,8 @@ public:
 	}
 
 	SuccessState RenderQueryResult(PrintStream &out, ShellState &state, RenderingQueryResult &result) override {
-		auto &mat = result.result.Cast<duckdb::MaterializedQueryResult>();
-		idx_t total = mat.RowCount();
+		const idx_t total_upper_bound = state.llm_bytes_budget;
+		idx_t total = 0;
 		idx_t budget = state.llm_bytes_budget;
 		idx_t trunc = state.llm_value_truncation;
 		auto &null_s = state.llm_null;
@@ -1604,6 +1604,13 @@ public:
 		bool truncation_warned = false;
 
 		for (auto &row : result) {
+			total ++;
+			if (total - shown >= total_upper_bound) {
+				break;
+			}
+			if (budget_hit) {
+				continue;
+			}
 			string line;
 			for (idx_t c = 0; c < row.data.size(); c++) {
 				if (c > 0) {
@@ -1647,7 +1654,7 @@ public:
 					             (unsigned long long)(line.size() + 60));
 				}
 				budget_hit = true;
-				break;
+				continue;
 			}
 			out.Print(line + "\n");
 			budget_used += line.size() + 1;
@@ -1657,7 +1664,11 @@ public:
 		// Footer
 		if (budget_hit) {
 			idx_t next_offset = current_offset + shown;
-			out.Print("(" + to_string(shown) + " rows, " + to_string(total - shown) +
+			string remaining = to_string(total - shown);
+			if (total - shown == total_upper_bound) {
+				remaining = "at least " + remaining;
+			}
+			out.Print("(" + to_string(shown) + " rows, " + remaining +
 			          " more \xe2\x80\x94 OFFSET " + to_string(next_offset) + ")\n");
 		} else {
 			out.Print("(" + to_string(shown) + " rows)\n");

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1665,11 +1665,13 @@ public:
 		if (budget_hit) {
 			idx_t next_offset = current_offset + shown;
 			string remaining = to_string(total - shown);
-			if (total - shown == total_upper_bound) {
-				remaining = "at least " + remaining;
+			if (total - shown >= total_upper_bound) {
+				remaining = "at least " + remaining + " more";
+			} else {
+				remaining = "exactly " + remaining + " more";
 			}
 			out.Print("(" + to_string(shown) + " rows, " + remaining +
-			          " more \xe2\x80\x94 OFFSET " + to_string(next_offset) + ")\n");
+			          " - paginate via OFFSET " + to_string(next_offset) + ")\n");
 		} else {
 			out.Print("(" + to_string(shown) + " rows)\n");
 		}

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -4,6 +4,10 @@
 #include "duckdb/common/box_renderer.hpp"
 #include "shell_highlight.hpp"
 #include "duckdb/logging/log_storage.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
+#include "duckdb/parser/result_modifier.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
 #include <stdexcept>
 #include <cstring>
 
@@ -1558,6 +1562,149 @@ public:
 };
 
 //===--------------------------------------------------------------------===//
+// LLM Renderer
+//===--------------------------------------------------------------------===//
+class ModeLlmRenderer : public ShellRenderer {
+public:
+	explicit ModeLlmRenderer(ShellState &state) : ShellRenderer(state) {
+	}
+
+	bool RequireMaterializedResult() const override {
+		return true;
+	}
+
+	bool ShouldUsePager(RenderingQueryResult &, PagerMode) override {
+		return false;
+	}
+
+	SuccessState RenderQueryResult(PrintStream &out, ShellState &state, RenderingQueryResult &result) override {
+		auto &mat = result.result.Cast<duckdb::MaterializedQueryResult>();
+		idx_t total = mat.RowCount();
+		idx_t budget = state.llm_bytes_budget;
+		idx_t trunc = state.llm_value_truncation;
+		auto &null_s = state.llm_null;
+		auto &cols = result.metadata.column_names;
+
+		// Detect existing top-level OFFSET so the footer computes the correct next offset
+		idx_t current_offset = ExtractTopLevelOffset(state.current_query);
+
+		// Header: pipe-separated column names, no padding
+		string header;
+		for (idx_t i = 0; i < cols.size(); i++) {
+			if (i > 0) {
+				header += " | ";
+			}
+			header += cols[i];
+		}
+		out.Print(header + "\n");
+
+		idx_t budget_used = header.size() + 1;
+		idx_t shown = 0;
+		bool budget_hit = false;
+		bool truncation_warned = false;
+
+		for (auto &row : result) {
+			string line;
+			for (idx_t c = 0; c < row.data.size(); c++) {
+				if (c > 0) {
+					line += " | ";
+				}
+				if (row.is_null[c]) {
+					line += null_s;
+				} else {
+					string val(row.data[c].GetString());
+					if (trunc > 0 && val.size() > trunc) {
+						if (trunc == 1) {
+							// trunc=1 would leave zero chars before the ellipsis — show at
+							// least one character and warn once per query
+							if (!truncation_warned) {
+								state.PrintF(PrintOutput::STDERR,
+								             "Warning: mode_llm_value_truncation (1) is too small to show any "
+								             "content before the ellipsis. Raise .mode_llm_value_truncation.\n");
+								truncation_warned = true;
+							}
+							val = string(1, val[0]) + "\xe2\x80\xa6";
+						} else {
+							// truncate and append UTF-8 ellipsis (…)
+							val = val.substr(0, trunc - 1) + "\xe2\x80\xa6";
+						}
+					}
+					line += val;
+				}
+			}
+			// Reserve ~60 bytes for the footer line.
+			// Always print at least one row — a budget so small that even the
+			// first row doesn't fit is a misconfiguration, not a reason to emit
+			// zero data. Log a warning so the user knows to raise mode_llm_bytes_budget.
+			if (budget > 0 && budget_used + line.size() + 60 > budget) {
+				if (shown == 0) {
+					out.Print(line + "\n");
+					shown++;
+					state.PrintF(PrintOutput::STDERR,
+					             "Warning: mode_llm_bytes_budget (%llu bytes) is smaller than a single row "
+					             "(%llu bytes). Raise .mode_llm_bytes_budget to suppress this warning.\n",
+					             (unsigned long long)budget,
+					             (unsigned long long)(line.size() + 60));
+				}
+				budget_hit = true;
+				break;
+			}
+			out.Print(line + "\n");
+			budget_used += line.size() + 1;
+			shown++;
+		}
+
+		// Footer
+		if (budget_hit) {
+			idx_t next_offset = current_offset + shown;
+			out.Print("(" + to_string(shown) + " rows, " + to_string(total - shown) +
+			          " more \xe2\x80\x94 OFFSET " + to_string(next_offset) + ")\n");
+		} else {
+			out.Print("(" + to_string(shown) + " rows)\n");
+		}
+
+		return SuccessState::SUCCESS;
+	}
+
+private:
+	// Read LimitModifier::offset on the outermost QueryNode.
+	// Returns 0 if absent (nullptr) — the only reliable way to tell the user
+	// didn't write OFFSET is that the pointer was never set by the parser.
+	static idx_t ExtractTopLevelOffset(const string &sql) {
+		if (sql.empty()) {
+			return 0;
+		}
+		try {
+			duckdb::Parser parser;
+			parser.ParseQuery(sql);
+			if (parser.statements.empty()) {
+				return 0;
+			}
+			auto &stmt = *parser.statements[0];
+			if (stmt.type != duckdb::StatementType::SELECT_STATEMENT) {
+				return 0;
+			}
+			auto &node = stmt.Cast<duckdb::SelectStatement>().node;
+			for (auto &mod : node->modifiers) {
+				if (mod->type != duckdb::ResultModifierType::LIMIT_MODIFIER) {
+					continue;
+				}
+				auto &lm = mod->Cast<duckdb::LimitModifier>();
+				if (!lm.offset) {
+					// LIMIT present but no OFFSET written by the user
+					return 0;
+				}
+				if (lm.offset->type == duckdb::ExpressionType::VALUE_CONSTANT) {
+					return lm.offset->Cast<duckdb::ConstantExpression>().value.GetValue<idx_t>();
+				}
+			}
+		} catch (...) {
+		}
+		return 0;
+	}
+};
+
+//===--------------------------------------------------------------------===//
 // DuckBox Renderer
 //===--------------------------------------------------------------------===//
 class DuckBoxRenderer : public duckdb::BaseResultRenderer {
@@ -1835,6 +1982,8 @@ unique_ptr<ShellRenderer> ShellState::GetRenderer(RenderMode mode) {
 		return make_uniq<ModeLatexRenderer>(*this);
 	case RenderMode::DUCKBOX:
 		return make_uniq<ModeDuckBoxRenderer>(*this);
+	case RenderMode::LLM:
+		return make_uniq<ModeLlmRenderer>(*this);
 	case RenderMode::DESCRIBE:
 		return make_uniq<ModeDescribeRenderer>(*this);
 	case RenderMode::TRASH:

--- a/tools/shell/shell_renderer.cpp
+++ b/tools/shell/shell_renderer.cpp
@@ -1604,7 +1604,7 @@ public:
 		bool truncation_warned = false;
 
 		for (auto &row : result) {
-			total ++;
+			total++;
 			if (total - shown >= total_upper_bound) {
 				break;
 			}
@@ -1650,8 +1650,7 @@ public:
 					state.PrintF(PrintOutput::STDERR,
 					             "Warning: mode_llm_bytes_budget (%llu bytes) is smaller than a single row "
 					             "(%llu bytes). Raise .mode_llm_bytes_budget to suppress this warning.\n",
-					             (unsigned long long)budget,
-					             (unsigned long long)(line.size() + 60));
+					             (unsigned long long)budget, (unsigned long long)(line.size() + 60));
 				}
 				budget_hit = true;
 				continue;
@@ -1670,8 +1669,8 @@ public:
 			} else {
 				remaining = "exactly " + remaining + " more";
 			}
-			out.Print("(" + to_string(shown) + " rows, " + remaining +
-			          " - paginate via OFFSET " + to_string(next_offset) + ")\n");
+			out.Print("(" + to_string(shown) + " rows, " + remaining + " - paginate via OFFSET " +
+			          to_string(next_offset) + ")\n");
 		} else {
 			out.Print("(" + to_string(shown) + " rows)\n");
 		}


### PR DESCRIPTION
Idea is compact approximate output bound to a given amount of bytes, and terminated by a hint that an offset query will work as pagination.

Goal here is providing as most information as viable in a limited number of bytes. This is opt-in, and will NOT be suited for all interactions between LLM and duckdb, but will work for simple loops of interactions back and forth, where an user (or an agent) can see only a fixed amount of data back, and take that as input in how to restructure the query / how to iterate.

Main goals:

### Fixed budged
LLM will be able to digest only some fixed amount of information (configurable via `.mode_llm_bytes_budget 10000`)

### Streaming query
Streaming query executed to get the relevant rows + up to N more (to compute a lower bound on count(*), but stop after that.
Idea is providing as much as information as possible in the limited number of bytes, and at the minimal cost.

A new iteration (potentially some filtering / aggregation / or paginated) could be used to get more values
Idea is that we compute only as long as needed. This would allow for example to terminate execution at an earlier stage. Example `FROM range(12412341234);` would still terminate after going through only a few vector sizes.

### Provide lower bound on count(*)
By streaming up to extra 4000 rows (configurable, also via `.mode_llm_bytes_budget 10000`), one can cheaply answer "how many more rows there are", I think there is lot of information on saying "there are 100 more" vs "there are at least 4000 more". Accurate count can be heavy to compute, so that will need to be queried explcitly.

### very basic type system
If types are relevant, a different output mode or an explcit DESCRIBE would be better placed.
Note strings are cut at length 70, idea that long strings carry little info (consuming potentially a lot of bytes). Again, other modes are exact version, this is an approximate fuzzy output mode.

### Suggest OFFSET pagination
That might be the weirder, but given some arbitrary SQL, how to do pagination?
My idea (that's for real mine), is as follow:
 * if there is an explicit OFFSET already (top level in the query) -> take that number + number of rows, and hint that could be the next OFFSET
 * if there is no offset, one can always wrap in FROM (<SQL>) OFFSET X, so suggest of adding OFFSET X
 The idea is that OFFSET is closed, at most adding it once will converge.

Note that OFFSET pagination might not be the best way, likely something similar to: `COPY FROM (<SQL>) TO '/tmp/file.parquet';`
and then reading the paginated results on the parquet file would be better, BUT note that pagination it's still needed for this second part (sure, one can do manually, but given the amount of rows is variable, I think it's nice to just point to it).

Examples:
```sql
SELECT 42, 'quack';
```
```
42 | 'quack'
42 | quack
(1 rows)
```

```sql
CALL dbgen(sf=1);
.mode llm
FROM lineitem;
```
```
l_orderkey | l_partkey | l_suppkey | l_linenumber | l_quantity | l_extendedprice | l_discount | l_tax | l_returnflag | l_linestatus | l_shipdate | l_commitdate | l_receiptdate | l_shipinstruct | l_shipmode | l_comment
1 | 155190 | 7706 | 1 | 17.00 | 21168.23 | 0.04 | 0.02 | N | O | 1996-03-13 | 1996-02-12 | 1996-03-22 | DELIVER IN PERSON | TRUCK | to beans x-ray carefull
1 | 67310 | 7311 | 2 | 36.00 | 45983.16 | 0.09 | 0.06 | N | O | 1996-04-12 | 1996-02-28 | 1996-04-20 | TAKE BACK RETURN | MAIL |  according to the final foxes. qui
1 | 63700 | 3701 | 3 | 8.00 | 13309.60 | 0.10 | 0.02 | N | O | 1996-01-29 | 1996-03-05 | 1996-01-31 | TAKE BACK RETURN | REG AIR | ourts cajole above the furiou
1 | 2132 | 4633 | 4 | 28.00 | 28955.64 | 0.09 | 0.06 | N | O | 1996-04-21 | 1996-03-30 | 1996-05-16 | NONE | AIR | s cajole busily above t
1 | 24027 | 1534 | 5 | 24.00 | 22824.48 | 0.10 | 0.04 | N | O | 1996-03-30 | 1996-03-14 | 1996-04-01 | NONE | FOB |  the regular, regular pa
1 | 15635 | 638 | 6 | 32.00 | 49620.16 | 0.07 | 0.02 | N | O | 1996-01-30 | 1996-02-07 | 1996-02-03 | DELIVER IN PERSON | MAIL | rouches. special 
2 | 106170 | 1191 | 1 | 38.00 | 44694.46 | 0.00 | 0.05 | N | O | 1997-01-28 | 1997-01-14 | 1997-02-02 | TAKE BACK RETURN | RAIL | re. enticingly regular instruct
3 | 4297 | 1798 | 1 | 45.00 | 54058.05 | 0.06 | 0.00 | R | F | 1994-02-02 | 1994-01-04 | 1994-02-23 | NONE | AIR | s cajole above the pinto beans. iro
3 | 19036 | 6540 | 2 | 49.00 | 46796.47 | 0.10 | 0.00 | R | F | 1993-11-09 | 1993-12-20 | 1993-11-24 | TAKE BACK RETURN | RAIL | ecial pinto beans. sly
3 | 128449 | 3474 | 3 | 27.00 | 39890.88 | 0.06 | 0.07 | A | F | 1994-01-16 | 1993-11-22 | 1994-01-23 | DELIVER IN PERSON | SHIP | e carefully fina
3 | 29380 | 1883 | 4 | 2.00 | 2618.76 | 0.01 | 0.06 | A | F | 1993-12-04 | 1994-01-07 | 1994-01-01 | NONE | TRUCK | ackages boost across 
3 | 183095 | 650 | 5 | 28.00 | 32986.52 | 0.04 | 0.00 | R | F | 1993-12-14 | 1994-01-10 | 1994-01-01 | TAKE BACK RETURN | FOB | heodolites haggle blit
3 | 62143 | 9662 | 6 | 26.00 | 28733.64 | 0.10 | 0.02 | A | F | 1993-10-29 | 1993-12-18 | 1993-11-04 | TAKE BACK RETURN | RAIL | telets x-ray quickly mult
4 | 88035 | 5560 | 1 | 30.00 | 30690.90 | 0.03 | 0.08 | N | O | 1996-01-10 | 1995-12-14 | 1996-01-18 | DELIVER IN PERSON | REG AIR | s. even ideas are above the accounts. 
5 | 108570 | 8571 | 1 | 15.00 | 23678.55 | 0.02 | 0.04 | R | F | 1994-10-31 | 1994-08-31 | 1994-11-20 | NONE | AIR | arefully regular t
5 | 123927 | 3928 | 2 | 26.00 | 50723.92 | 0.07 | 0.08 | R | F | 1994-10-16 | 1994-09-25 | 1994-10-19 | NONE | FOB |  theodolites. slyly pending dolphins 
5 | 37531 | 35 | 3 | 50.00 | 73426.50 | 0.08 | 0.03 | A | F | 1994-08-08 | 1994-10-13 | 1994-08-26 | DELIVER IN PERSON | AIR | odolites. bold accounts alo
6 | 139636 | 2150 | 1 | 37.00 | 61998.31 | 0.08 | 0.03 | A | F | 1992-04-27 | 1992-05-15 | 1992-05-02 | TAKE BACK RETURN | TRUCK | ly silent ideas! carefull
7 | 182052 | 9607 | 1 | 12.00 | 13608.60 | 0.07 | 0.03 | N | O | 1996-05-07 | 1996-03-13 | 1996-06-03 | TAKE BACK RETURN | FOB | bout the silent, ironic sentim
7 | 145243 | 7758 | 2 | 9.00 | 11594.16 | 0.08 | 0.08 | N | O | 1996-02-01 | 1996-03-02 | 1996-02-19 | TAKE BACK RETURN | SHIP | ic packages slee
7 | 94780 | 9799 | 3 | 46.00 | 81639.88 | 0.10 | 0.07 | N | O | 1996-01-15 | 1996-03-27 | 1996-02-03 | COLLECT COD | MAIL | accounts. reque
7 | 163073 | 3074 | 4 | 28.00 | 31809.96 | 0.03 | 0.04 | N | O | 1996-03-21 | 1996-04-08 | 1996-04-20 | NONE | FOB | ng theodolites run furiously. 
7 | 151894 | 9440 | 5 | 38.00 | 73943.82 | 0.08 | 0.01 | N | O | 1996-02-11 | 1996-02-24 | 1996-02-18 | DELIVER IN PERSON | TRUCK | he final, daring excuses. furiously eve
7 | 79251 | 1759 | 6 | 35.00 | 43058.75 | 0.06 | 0.03 | N | O | 1996-01-16 | 1996-02-23 | 1996-01-22 | TAKE BACK RETURN | FOB | ely pending deposits. quietly unusual requ
(24 rows, at least 4000 more - paginate via OFFSET 24)
```

```sql
FROM lineitem WHERE l_shipmode == 'TRUCK' AND l_orderkey < 10000;
```
```
...data...
(24 rows, exactly 1435 more - paginate via OFFSET 24)
```
```sql
FROM lineitem WHERE l_shipmode == 'TRUCK' AND l_orderkey < 10000 OFFSET 24;
```
```
...data...
(24 rows, exactly 1411 more - paginate via OFFSET 48)
```