### PR TITLE
Redirect attach

### DIFF
--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library_unity(
   glob.cpp
   query_function.cpp
   range.cpp
+  redirect.cpp
   repeat.cpp
   repeat_row.cpp
   copy_csv.cpp

--- a/src/function/table/range.cpp
+++ b/src/function/table/range.cpp
@@ -438,6 +438,7 @@ void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 
 void BuiltinFunctions::RegisterTableFunctions() {
 	CheckpointFunction::RegisterFunction(*this);
+	RedirectCreateFunction::RegisterFunction(*this);
 	GlobTableFunction::RegisterFunction(*this);
 	RangeTableFunction::RegisterFunction(*this);
 	RepeatTableFunction::RegisterFunction(*this);

--- a/src/function/table/redirect.cpp
+++ b/src/function/table/redirect.cpp
@@ -1,0 +1,133 @@
+#include "duckdb/function/table/range.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/checksum.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/storage/storage_info.hpp"
+#include "duckdb/storage/redirect_info.hpp"
+
+namespace duckdb {
+
+//! Write a header-only pointer file: a valid DuckDB container whose MainHeader carries a redirect record and
+//! whose (empty) DatabaseHeaders use the latest storage version, so a reader without redirect support hard-fails
+//! instead of silently opening it as an empty database. Mirrors the default single-file header block layout.
+static void WriteRedirectPointerFile(FileSystem &fs, const string &path, const RedirectInfo &redirect,
+                                     bool overwrite) {
+	if (!overwrite && fs.FileExists(path)) {
+		throw IOException("redirect_create: file \"%s\" already exists (pass overwrite => true to replace it)", path);
+	}
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+
+	constexpr idx_t block_header = Storage::DEFAULT_BLOCK_HEADER_SIZE;
+	constexpr idx_t file_header = Storage::FILE_HEADER_SIZE;
+	constexpr idx_t data_size = file_header - block_header;
+
+	auto block = make_unsafe_uniq_array<data_t>(file_header);
+
+	// MainHeader block: carries the redirect record. The checksum covers the data region after the block header.
+	memset(block.get(), 0, file_header);
+	MainHeader main_header {};
+	main_header.version_number = VERSION_NUMBER;
+	main_header.SetRedirect();
+	main_header.redirect = redirect;
+	main_header.redirect.is_redirect = true;
+	{
+		MemoryStream ser(block.get() + block_header, data_size);
+		main_header.Write(ser);
+	}
+	Store<uint64_t>(Checksum(block.get() + block_header, data_size), block.get());
+	handle->Write(QueryContext(), block.get(), file_header, 0);
+
+	// Two empty DatabaseHeaders with the latest storage version (poisons old readers).
+	for (idx_t i = 1; i <= 2; i++) {
+		memset(block.get(), 0, file_header);
+		DatabaseHeader db_header;
+		db_header.iteration = 0;
+		db_header.meta_block = idx_t(INVALID_BLOCK);
+		db_header.free_list = idx_t(INVALID_BLOCK);
+		db_header.block_count = 0;
+		db_header.block_alloc_size = DEFAULT_BLOCK_ALLOC_SIZE;
+		db_header.vector_size = STANDARD_VECTOR_SIZE;
+		db_header.storage_compatibility = StorageVersion::V2_0_0;
+		MemoryStream ser(block.get() + block_header, data_size);
+		db_header.Write(ser);
+		Store<uint64_t>(Checksum(block.get() + block_header, data_size), block.get());
+		handle->Write(QueryContext(), block.get(), file_header, file_header * i);
+	}
+	handle->Sync();
+}
+
+struct RedirectCreateBindData : public TableFunctionData {
+	string path;
+	RedirectInfo redirect;
+	bool overwrite = false;
+};
+
+static unique_ptr<FunctionData> RedirectCreateBind(ClientContext &context, TableFunctionBindInput &input,
+                                                   vector<LogicalType> &return_types, vector<string> &names) {
+	auto result = make_uniq<RedirectCreateBindData>();
+	if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
+		throw BinderException("redirect_create: the pointer path and target cannot be NULL");
+	}
+	result->path = StringValue::Get(input.inputs[0]);
+	result->redirect.is_redirect = true;
+	result->redirect.target = StringValue::Get(input.inputs[1]);
+	result->redirect.type = "duckdb";
+
+	for (auto &param : input.named_parameters) {
+		if (param.second.IsNull()) {
+			continue;
+		}
+		if (param.first == "type") {
+			result->redirect.type = StringValue::Get(param.second);
+		} else if (param.first == "overwrite") {
+			result->overwrite = BooleanValue::Get(param.second);
+		} else if (param.first == "options") {
+			auto &entries = ListValue::GetChildren(param.second);
+			for (auto &entry : entries) {
+				auto &kv = StructValue::GetChildren(entry);
+				result->redirect.options.push_back(
+				    {StringValue::Get(kv[0].DefaultCastAs(LogicalType::VARCHAR)),
+				     StringValue::Get(kv[1].DefaultCastAs(LogicalType::VARCHAR))});
+			}
+		}
+	}
+
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("path");
+	return std::move(result);
+}
+
+struct RedirectCreateState : public GlobalTableFunctionState {
+	bool finished = false;
+};
+
+static unique_ptr<GlobalTableFunctionState> RedirectCreateInit(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<RedirectCreateState>();
+}
+
+static void RedirectCreateFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<RedirectCreateBindData>();
+	auto &state = data_p.global_state->Cast<RedirectCreateState>();
+	if (state.finished) {
+		return;
+	}
+	auto &fs = FileSystem::GetFileSystem(context);
+	WriteRedirectPointerFile(fs, bind_data.path, bind_data.redirect, bind_data.overwrite);
+	output.data[0].Append(Value(bind_data.path));
+	state.finished = true;
+}
+
+void RedirectCreateFunction::RegisterFunction(BuiltinFunctions &set) {
+	TableFunction redirect_create("redirect_create", {LogicalType::VARCHAR, LogicalType::VARCHAR}, RedirectCreateFunc,
+	                              RedirectCreateBind, RedirectCreateInit);
+	redirect_create.named_parameters["type"] = LogicalType::VARCHAR;
+	redirect_create.named_parameters["overwrite"] = LogicalType::BOOLEAN;
+	redirect_create.named_parameters["options"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
+	set.AddFunction(redirect_create);
+}
+
+} // namespace duckdb

--- a/src/function/table/redirect.cpp
+++ b/src/function/table/redirect.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/storage/storage_info.hpp"
 #include "duckdb/storage/redirect_info.hpp"
+#include "duckdb/storage/magic_bytes.hpp"
 
 namespace duckdb {
 
@@ -15,10 +16,26 @@ namespace duckdb {
 //! DatabaseHeaders carry the redirect record. Storing the record in the DatabaseHeaders (not the MainHeader) lets a
 //! later re-point swap it atomically via the h1/h2 iteration count, and rides the block-encryption path when the
 //! pointer is encrypted. h1 is the active slot; h2 is a valid fallback. Mirrors the default header block layout.
-static void WriteRedirectPointerFile(FileSystem &fs, const string &path, const RedirectInfo &redirect,
+static void WriteRedirectPointerFile(ClientContext &context, const string &path, const RedirectInfo &redirect,
                                      bool overwrite) {
-	if (!overwrite && fs.FileExists(path)) {
-		throw IOException("redirect_create: file \"%s\" already exists (pass overwrite => true to replace it)", path);
+	auto &fs = FileSystem::GetFileSystem(context);
+
+	// Inspect any existing file before writing. A redirect pointer may be replaced, but a real database or a
+	// foreign file must never be clobbered: overwriting a database would stamp a pointer header over it and
+	// orphan its data. So `overwrite` means "replace this pointer", never "clobber whatever is there".
+	if (fs.FileExists(path)) {
+		if (!overwrite) {
+			throw IOException("redirect_create: file \"%s\" already exists (pass overwrite => true to replace it)",
+			                  path);
+		}
+		RedirectInfo existing;
+		auto existing_type = MagicBytes::CheckMagicBytes(context, fs, path, nullptr, &existing);
+		if (!(existing_type == DataFileType::DUCKDB_FILE && existing.is_redirect)) {
+			throw IOException(
+			    "redirect_create: refusing to overwrite \"%s\": it is not a redirect pointer file. Delete it first "
+			    "if you really mean to replace it.",
+			    path);
+		}
 	}
 	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
 
@@ -116,8 +133,7 @@ static void RedirectCreateFunc(ClientContext &context, TableFunctionInput &data_
 	if (state.finished) {
 		return;
 	}
-	auto &fs = FileSystem::GetFileSystem(context);
-	WriteRedirectPointerFile(fs, bind_data.path, bind_data.redirect, bind_data.overwrite);
+	WriteRedirectPointerFile(context, bind_data.path, bind_data.redirect, bind_data.overwrite);
 	output.data[0].Append(Value(bind_data.path));
 	state.finished = true;
 }

--- a/src/function/table/redirect.cpp
+++ b/src/function/table/redirect.cpp
@@ -17,7 +17,7 @@ namespace duckdb {
 //! later re-point swap it atomically via the h1/h2 iteration count, and rides the block-encryption path when the
 //! pointer is encrypted. h1 is the active slot; h2 is a valid fallback. Mirrors the default header block layout.
 static void WriteRedirectPointerFile(ClientContext &context, const string &path, const RedirectInfo &redirect,
-                                     bool overwrite) {
+                                     bool overwrite, StorageVersion storage_version) {
 	auto &fs = FileSystem::GetFileSystem(context);
 
 	// Inspect any existing file before writing. A redirect pointer may be replaced, but a real database or a
@@ -67,7 +67,7 @@ static void WriteRedirectPointerFile(ClientContext &context, const string &path,
 		db_header.block_count = 0;
 		db_header.block_alloc_size = DEFAULT_BLOCK_ALLOC_SIZE;
 		db_header.vector_size = STANDARD_VECTOR_SIZE;
-		db_header.storage_compatibility = StorageVersion::V2_0_0;
+		db_header.storage_compatibility = storage_version;
 		db_header.redirect = redirect;
 		db_header.redirect.is_redirect = true;
 		MemoryStream ser(block.get() + block_header, data_size);
@@ -82,6 +82,9 @@ struct RedirectCreateBindData : public TableFunctionData {
 	string path;
 	RedirectInfo redirect;
 	bool overwrite = false;
+	//! Pointer files are written at >= v2.0.0 so older DuckDB versions reject them (rather than opening them as an
+	//! empty database). Defaults to the earliest version that guarantees that.
+	StorageVersion storage_version = StorageVersion::V2_0_0;
 };
 
 static unique_ptr<FunctionData> RedirectCreateBind(ClientContext &context, TableFunctionBindInput &input,
@@ -103,6 +106,20 @@ static unique_ptr<FunctionData> RedirectCreateBind(ClientContext &context, Table
 			result->redirect.type = StringValue::Get(param.second);
 		} else if (param.first == "overwrite") {
 			result->overwrite = BooleanValue::Get(param.second);
+		} else if (param.first == "storage_version") {
+			auto version_string = StringValue::Get(param.second);
+			auto version = GetStorageVersion(version_string.c_str());
+			if (version == StorageVersion::INVALID) {
+				throw InvalidInputException("redirect_create: unknown storage version \"%s\"", version_string);
+			}
+			if (version < StorageVersion::V2_0_0) {
+				throw InvalidInputException(
+				    "redirect_create: storage version \"%s\" is too old for a redirect pointer file - it must be "
+				    "v2.0.0 or newer so that older DuckDB versions reject the pointer instead of opening it as an "
+				    "empty database",
+				    version_string);
+			}
+			result->storage_version = version;
 		} else if (param.first == "options") {
 			auto &entries = ListValue::GetChildren(param.second);
 			for (auto &entry : entries) {
@@ -133,7 +150,8 @@ static void RedirectCreateFunc(ClientContext &context, TableFunctionInput &data_
 	if (state.finished) {
 		return;
 	}
-	WriteRedirectPointerFile(context, bind_data.path, bind_data.redirect, bind_data.overwrite);
+	WriteRedirectPointerFile(context, bind_data.path, bind_data.redirect, bind_data.overwrite,
+	                         bind_data.storage_version);
 	output.data[0].Append(Value(bind_data.path));
 	state.finished = true;
 }
@@ -143,6 +161,7 @@ void RedirectCreateFunction::RegisterFunction(BuiltinFunctions &set) {
 	                              RedirectCreateBind, RedirectCreateInit);
 	redirect_create.named_parameters["type"] = LogicalType::VARCHAR;
 	redirect_create.named_parameters["overwrite"] = LogicalType::BOOLEAN;
+	redirect_create.named_parameters["storage_version"] = LogicalType::VARCHAR;
 	redirect_create.named_parameters["options"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
 	set.AddFunction(redirect_create);
 }

--- a/src/function/table/redirect.cpp
+++ b/src/function/table/redirect.cpp
@@ -88,7 +88,7 @@ struct RedirectCreateBindData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> RedirectCreateBind(ClientContext &context, TableFunctionBindInput &input,
-                                                   vector<LogicalType> &return_types, vector<string> &names) {
+                                                   vector<LogicalType> &return_types, vector<Identifier> &names) {
 	auto result = make_uniq<RedirectCreateBindData>();
 	if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
 		throw BinderException("redirect_create: the pointer path and target cannot be NULL");

--- a/src/function/table/redirect.cpp
+++ b/src/function/table/redirect.cpp
@@ -1,6 +1,9 @@
 #include "duckdb/function/table/range.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database_manager.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/checksum.hpp"
 #include "duckdb/common/helper.hpp"
@@ -87,22 +90,59 @@ struct RedirectCreateBindData : public TableFunctionData {
 	StorageVersion storage_version = StorageVersion::V2_0_0;
 };
 
+//! Derive a redirect record from a currently-attached database: capture its resolved path, storage type, and the
+//! options it was attached with, so a pointer created this way reopens the same target the same way.
+static void DeriveRedirectFromAttachedDatabase(ClientContext &context, const string &db_name, RedirectInfo &redirect) {
+	auto &db_manager = DatabaseManager::Get(context);
+	auto db = db_manager.GetDatabase(context, Identifier(db_name));
+	if (!db) {
+		throw BinderException("redirect_create: database \"%s\" is not attached", db_name);
+	}
+	auto &catalog = db->GetCatalog();
+	if (catalog.InMemory()) {
+		throw BinderException("redirect_create: database \"%s\" is in-memory, so there is no target to redirect to",
+		                      db_name);
+	}
+	if (catalog.IsEncrypted()) {
+		throw BinderException(
+		    "redirect_create: database \"%s\" is encrypted; its key cannot be captured into a pointer file", db_name);
+	}
+	redirect.target = catalog.GetDBPath();
+	redirect.type = catalog.GetCatalogType();
+	if (db->IsReadOnly()) {
+		redirect.options.push_back({"read_only", "true"});
+	}
+	for (auto &option : db->GetAttachOptions()) {
+		redirect.options.push_back({option.first, option.second.ToString()});
+	}
+}
+
 static unique_ptr<FunctionData> RedirectCreateBind(ClientContext &context, TableFunctionBindInput &input,
                                                    vector<LogicalType> &return_types, vector<Identifier> &names) {
 	auto result = make_uniq<RedirectCreateBindData>();
-	if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
-		throw BinderException("redirect_create: the pointer path and target cannot be NULL");
+	if (input.inputs[0].IsNull()) {
+		throw BinderException("redirect_create: the pointer path cannot be NULL");
 	}
 	result->path = StringValue::Get(input.inputs[0]);
 	result->redirect.is_redirect = true;
-	result->redirect.target = StringValue::Get(input.inputs[1]);
 	result->redirect.type = "duckdb";
 
+	// Overload A: the second positional argument names a currently-attached database to capture.
+	if (input.inputs.size() == 2) {
+		if (input.inputs[1].IsNull()) {
+			throw BinderException("redirect_create: the source database name cannot be NULL");
+		}
+		DeriveRedirectFromAttachedDatabase(context, StringValue::Get(input.inputs[1]), result->redirect);
+	}
+
+	// Overload B (and shared options): explicit target via `path`/`type`/`attach_options`, plus overwrite/version.
 	for (auto &param : input.named_parameters) {
 		if (param.second.IsNull()) {
 			continue;
 		}
-		if (param.first == "type") {
+		if (param.first == "path") {
+			result->redirect.target = StringValue::Get(param.second);
+		} else if (param.first == "type") {
 			result->redirect.type = StringValue::Get(param.second);
 		} else if (param.first == "overwrite") {
 			result->overwrite = BooleanValue::Get(param.second);
@@ -120,7 +160,7 @@ static unique_ptr<FunctionData> RedirectCreateBind(ClientContext &context, Table
 				    version_string);
 			}
 			result->storage_version = version;
-		} else if (param.first == "options") {
+		} else if (param.first == "attach_options") {
 			auto &entries = ListValue::GetChildren(param.second);
 			for (auto &entry : entries) {
 				auto &kv = StructValue::GetChildren(entry);
@@ -129,6 +169,11 @@ static unique_ptr<FunctionData> RedirectCreateBind(ClientContext &context, Table
 				     StringValue::Get(kv[1].DefaultCastAs(LogicalType::VARCHAR))});
 			}
 		}
+	}
+
+	if (result->redirect.target.empty()) {
+		throw BinderException("redirect_create: no target specified - pass a second argument naming an attached "
+		                      "database, or the `path` named parameter");
 	}
 
 	return_types.emplace_back(LogicalType::VARCHAR);
@@ -157,12 +202,24 @@ static void RedirectCreateFunc(ClientContext &context, TableFunctionInput &data_
 }
 
 void RedirectCreateFunction::RegisterFunction(BuiltinFunctions &set) {
-	TableFunction redirect_create("redirect_create", {LogicalType::VARCHAR, LogicalType::VARCHAR}, RedirectCreateFunc,
-	                              RedirectCreateBind, RedirectCreateInit);
-	redirect_create.named_parameters["type"] = LogicalType::VARCHAR;
-	redirect_create.named_parameters["overwrite"] = LogicalType::BOOLEAN;
-	redirect_create.named_parameters["storage_version"] = LogicalType::VARCHAR;
-	redirect_create.named_parameters["options"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
+	TableFunctionSet redirect_create("redirect_create");
+
+	// Overload A: redirect_create('pointer.db', 'attached_db_name') - capture a currently-attached database.
+	TableFunction from_database({LogicalType::VARCHAR, LogicalType::VARCHAR}, RedirectCreateFunc, RedirectCreateBind,
+	                            RedirectCreateInit);
+	from_database.named_parameters["overwrite"] = LogicalType::BOOLEAN;
+	from_database.named_parameters["storage_version"] = LogicalType::VARCHAR;
+	redirect_create.AddFunction(from_database);
+
+	// Overload B: redirect_create('pointer.db', path := ..., type := ..., attach_options := {...}) - explicit target.
+	TableFunction explicit_target({LogicalType::VARCHAR}, RedirectCreateFunc, RedirectCreateBind, RedirectCreateInit);
+	explicit_target.named_parameters["path"] = LogicalType::VARCHAR;
+	explicit_target.named_parameters["type"] = LogicalType::VARCHAR;
+	explicit_target.named_parameters["attach_options"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
+	explicit_target.named_parameters["overwrite"] = LogicalType::BOOLEAN;
+	explicit_target.named_parameters["storage_version"] = LogicalType::VARCHAR;
+	redirect_create.AddFunction(explicit_target);
+
 	set.AddFunction(redirect_create);
 }
 

--- a/src/function/table/redirect.cpp
+++ b/src/function/table/redirect.cpp
@@ -11,9 +11,10 @@
 
 namespace duckdb {
 
-//! Write a header-only pointer file: a valid DuckDB container whose MainHeader carries a redirect record and
-//! whose (empty) DatabaseHeaders use the latest storage version, so a reader without redirect support hard-fails
-//! instead of silently opening it as an empty database. Mirrors the default single-file header block layout.
+//! Write a pointer file: a valid DuckDB container whose MainHeader carries only the redirect flag and whose two
+//! DatabaseHeaders carry the redirect record. Storing the record in the DatabaseHeaders (not the MainHeader) lets a
+//! later re-point swap it atomically via the h1/h2 iteration count, and rides the block-encryption path when the
+//! pointer is encrypted. h1 is the active slot; h2 is a valid fallback. Mirrors the default header block layout.
 static void WriteRedirectPointerFile(FileSystem &fs, const string &path, const RedirectInfo &redirect,
                                      bool overwrite) {
 	if (!overwrite && fs.FileExists(path)) {
@@ -27,13 +28,11 @@ static void WriteRedirectPointerFile(FileSystem &fs, const string &path, const R
 
 	auto block = make_unsafe_uniq_array<data_t>(file_header);
 
-	// MainHeader block: carries the redirect record. The checksum covers the data region after the block header.
+	// MainHeader block: carries the redirect flag + identity only. The record lives in the DatabaseHeaders below.
 	memset(block.get(), 0, file_header);
 	MainHeader main_header {};
 	main_header.version_number = VERSION_NUMBER;
 	main_header.SetRedirect();
-	main_header.redirect = redirect;
-	main_header.redirect.is_redirect = true;
 	{
 		MemoryStream ser(block.get() + block_header, data_size);
 		main_header.Write(ser);
@@ -41,17 +40,19 @@ static void WriteRedirectPointerFile(FileSystem &fs, const string &path, const R
 	Store<uint64_t>(Checksum(block.get() + block_header, data_size), block.get());
 	handle->Write(QueryContext(), block.get(), file_header, 0);
 
-	// Two empty DatabaseHeaders with the latest storage version (poisons old readers).
+	// Two DatabaseHeaders, both carrying the redirect record. h1 is active (higher iteration); h2 is a valid fallback.
 	for (idx_t i = 1; i <= 2; i++) {
 		memset(block.get(), 0, file_header);
 		DatabaseHeader db_header;
-		db_header.iteration = 0;
+		db_header.iteration = (i == 1) ? 1 : 0;
 		db_header.meta_block = idx_t(INVALID_BLOCK);
 		db_header.free_list = idx_t(INVALID_BLOCK);
 		db_header.block_count = 0;
 		db_header.block_alloc_size = DEFAULT_BLOCK_ALLOC_SIZE;
 		db_header.vector_size = STANDARD_VECTOR_SIZE;
 		db_header.storage_compatibility = StorageVersion::V2_0_0;
+		db_header.redirect = redirect;
+		db_header.redirect.is_redirect = true;
 		MemoryStream ser(block.get() + block_header, data_size);
 		db_header.Write(ser);
 		Store<uint64_t>(Checksum(block.get() + block_header, data_size), block.get());

--- a/src/include/duckdb/function/table/range.hpp
+++ b/src/include/duckdb/function/table/range.hpp
@@ -17,6 +17,10 @@ struct CheckpointFunction {
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
+struct RedirectCreateFunction {
+	static void RegisterFunction(BuiltinFunctions &set);
+};
+
 struct GlobTableFunction {
 	static void RegisterFunction(BuiltinFunctions &set);
 };

--- a/src/include/duckdb/main/attached_database.hpp
+++ b/src/include/duckdb/main/attached_database.hpp
@@ -67,6 +67,11 @@ struct AttachOptions {
 	//! Constructor for databases we attach when using ATTACH DATABASE.
 	AttachOptions(const unordered_map<string, Value> &options, const AccessMode default_access_mode);
 
+	//! Apply a single (key, value) ATTACH option: a core-consumed key updates the matching typed field, any other
+	//! key lands in `options`. Shared by the constructor and by late option sources (e.g. redirect records) so a
+	//! core option merged after construction still reaches its typed field instead of being rejected as unknown.
+	void ApplyOption(const string &key, const Value &value);
+
 	//! Defaults to the access mode configured in the DBConfig, unless specified otherwise.
 	AccessMode access_mode;
 	//! The recovery type of the database.

--- a/src/include/duckdb/main/database_path_and_type.hpp
+++ b/src/include/duckdb/main/database_path_and_type.hpp
@@ -16,17 +16,20 @@ namespace duckdb {
 
 class QueryContext;
 struct PrefetchedFileData;
+struct RedirectInfo;
 
 struct DBPathAndType {
 	//! Parse database extension type and rest of path from combined form (type:path)
 	static void ExtractExtensionPrefix(string &path, string &db_type);
 	//! Check the magic bytes of a file and set the database type. For a DuckDB file, the prefetched header is
-	//! returned through `out_prefetch` when set.
+	//! returned through `out_prefetch` when set, and a redirect record (if any) through `out_redirect`.
 	static void CheckMagicBytes(QueryContext context, FileSystem &fs, string &path, string &db_type,
-	                            optional_ptr<PrefetchedFileData> out_prefetch = nullptr);
+	                            optional_ptr<PrefetchedFileData> out_prefetch = nullptr,
+	                            optional_ptr<RedirectInfo> out_redirect = nullptr);
 
-	//! Run ExtractExtensionPrefix followed by CheckMagicBytes. Same `out_prefetch` semantics as CheckMagicBytes.
+	//! Run ExtractExtensionPrefix followed by CheckMagicBytes. Same `out_prefetch`/`out_redirect` semantics.
 	static void ResolveDatabaseType(FileSystem &fs, string &path, string &db_type,
-	                                optional_ptr<PrefetchedFileData> out_prefetch = nullptr);
+	                                optional_ptr<PrefetchedFileData> out_prefetch = nullptr,
+	                                optional_ptr<RedirectInfo> out_redirect = nullptr);
 };
 } // namespace duckdb

--- a/src/include/duckdb/storage/magic_bytes.hpp
+++ b/src/include/duckdb/storage/magic_bytes.hpp
@@ -15,6 +15,7 @@ namespace duckdb {
 class FileSystem;
 class QueryContext;
 struct PrefetchedFileData;
+struct RedirectInfo;
 
 enum class DataFileType : uint8_t {
 	FILE_DOES_NOT_EXIST, // file does not exist
@@ -28,8 +29,11 @@ class MagicBytes {
 public:
 	//! Detect the file type at `path` from its magic bytes. For a DuckDB file, a prefetched header prefix is
 	//! returned through `out_prefetch` (when set) so a later storage open reuses it instead of re-reading.
+	//! When `out_redirect` is set and the DuckDB file carries a redirect record, it is parsed from the
+	//! prefetched bytes into `out_redirect` (no extra I/O).
 	static DataFileType CheckMagicBytes(QueryContext context, FileSystem &fs, const string &path,
-	                                    optional_ptr<PrefetchedFileData> out_prefetch = nullptr);
+	                                    optional_ptr<PrefetchedFileData> out_prefetch = nullptr,
+	                                    optional_ptr<RedirectInfo> out_redirect = nullptr);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb/storage/redirect_info.hpp
+++ b/src/include/duckdb/storage/redirect_info.hpp
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/storage/redirect_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/string.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/common/pair.hpp"
+
+namespace duckdb {
+class WriteStream;
+class ReadStream;
+
+//! A single stored ATTACH option carried by a redirect record.
+struct RedirectOption {
+	string key;
+	string value;
+};
+
+//! An optional record, appended to the MainHeader, that turns a DuckDB file into a pointer: on ATTACH the
+//! pointer file is not opened, but the ATTACH is reinterpreted to open `target` (as storage type `type`).
+struct RedirectInfo {
+	//! The record format version, independently versioned from the storage format so the layout can grow.
+	static constexpr uint8_t CURRENT_VERSION = 1;
+	//! Cap on the serialized record size so it always fits inside the checksummed 4KiB header block.
+	static constexpr idx_t MAX_RECORD_SIZE = 3072;
+
+	//! Whether a redirect record is present.
+	bool is_redirect = false;
+	//! The record format version.
+	uint8_t version = CURRENT_VERSION;
+	//! The storage type of the target (e.g. duckdb / iceberg / postgres / sqlite). Empty means duckdb.
+	string type;
+	//! The path / URI / connection target of the database this pointer redirects to.
+	string target;
+	//! Stored ATTACH options merged into the reinterpreted ATTACH (user-supplied options win).
+	vector<RedirectOption> options;
+
+	bool IsRedirect() const {
+		return is_redirect;
+	}
+
+	//! Serialize the record body (everything after the MainHeader flags).
+	void Serialize(WriteStream &ser) const;
+	//! Deserialize a record body written by Serialize.
+	static RedirectInfo Deserialize(ReadStream &source);
+};
+
+} // namespace duckdb

--- a/src/include/duckdb/storage/redirect_info.hpp
+++ b/src/include/duckdb/storage/redirect_info.hpp
@@ -11,7 +11,6 @@
 #include "duckdb/common/constants.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/vector.hpp"
-#include "duckdb/common/pair.hpp"
 
 namespace duckdb {
 class WriteStream;

--- a/src/include/duckdb/storage/redirect_info.hpp
+++ b/src/include/duckdb/storage/redirect_info.hpp
@@ -22,8 +22,9 @@ struct RedirectOption {
 	string value;
 };
 
-//! An optional record, appended to the MainHeader, that turns a DuckDB file into a pointer: on ATTACH the
+//! An optional record, appended to the DatabaseHeader, that turns a DuckDB file into a pointer: on ATTACH the
 //! pointer file is not opened, but the ATTACH is reinterpreted to open `target` (as storage type `type`).
+//! It lives in the DatabaseHeader (not the MainHeader) so re-pointing is atomic via the h1/h2 iteration swap.
 struct RedirectInfo {
 	//! The record format version, independently versioned from the storage format so the layout can grow.
 	static constexpr uint8_t CURRENT_VERSION = 1;

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -265,8 +265,6 @@ public:
 	uint64_t flags[FLAG_COUNT];
 	//! Encryption version
 	uint8_t encryption_version;
-	//! The redirect record. Only serialized/read when REDIRECT_DATABASE_FLAG is set.
-	RedirectInfo redirect;
 
 	//! The length of the unique database identifier.
 	static constexpr idx_t DB_IDENTIFIER_LEN = 16;
@@ -401,6 +399,10 @@ struct DatabaseHeader {
 	idx_t vector_size = 0;
 	//! The storage compatibility version
 	StorageVersion storage_compatibility = StorageVersion::INVALID;
+	//! The redirect record, appended after the fixed fields when the MainHeader REDIRECT_DATABASE_FLAG is set.
+	//! It lives here (not in the MainHeader) so re-pointing is atomic via the h1/h2 iteration swap, and so it
+	//! rides the standard block-encryption path when the pointer file is encrypted.
+	RedirectInfo redirect;
 
 	void Write(WriteStream &ser);
 	static DatabaseHeader Read(const MainHeader &header, ReadStream &source);

--- a/src/include/duckdb/storage/storage_info.hpp
+++ b/src/include/duckdb/storage/storage_info.hpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/query_context.hpp"
+#include "duckdb/storage/redirect_info.hpp"
 
 namespace duckdb {
 
@@ -247,6 +248,8 @@ public:
 
 	//! Indicates whether database is encrypted or not.
 	static constexpr uint64_t ENCRYPTED_DATABASE_FLAG = 1;
+	//! Indicates whether this file is a redirect pointer: a redirect record follows the fixed MainHeader fields.
+	static constexpr uint64_t REDIRECT_DATABASE_FLAG = 2;
 	//! The encryption key length.
 	static constexpr uint64_t DEFAULT_ENCRYPTION_KEY_LENGTH = 32;
 	//! The magic bytes in front of the file should be "DUCK".
@@ -262,6 +265,8 @@ public:
 	uint64_t flags[FLAG_COUNT];
 	//! Encryption version
 	uint8_t encryption_version;
+	//! The redirect record. Only serialized/read when REDIRECT_DATABASE_FLAG is set.
+	RedirectInfo redirect;
 
 	//! The length of the unique database identifier.
 	static constexpr idx_t DB_IDENTIFIER_LEN = 16;
@@ -291,6 +296,12 @@ public:
 	}
 	void SetEncrypted() {
 		flags[0] |= MainHeader::ENCRYPTED_DATABASE_FLAG;
+	}
+	bool IsRedirect() const {
+		return flags[0] & MainHeader::REDIRECT_DATABASE_FLAG;
+	}
+	void SetRedirect() {
+		flags[0] |= MainHeader::REDIRECT_DATABASE_FLAG;
 	}
 	void SetEncryptionVersion(uint8_t version) {
 		encryption_version = version;
@@ -355,7 +366,9 @@ public:
 	}
 
 	void Write(WriteStream &ser);
-	static MainHeader Read(ReadStream &source);
+	//! Read a MainHeader. When check_version is false the storage-version gate is skipped, which is used to
+	//! detect a redirect pointer file (a poisoned storage version must not throw before the redirect fires).
+	static MainHeader Read(ReadStream &source, bool check_version = true);
 
 private:
 	data_t library_git_desc[MAX_VERSION_SIZE];

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -45,69 +45,72 @@ AttachOptions::AttachOptions(const DBConfigOptions &options)
 AttachOptions::AttachOptions(const unordered_map<string, Value> &attach_options, const AccessMode default_access_mode)
     : access_mode(default_access_mode) {
 	for (auto &entry : attach_options) {
-		if (entry.first == "readonly" || entry.first == "read_only") {
-			// Extract the read access mode.
-			auto read_only = BooleanValue::Get(entry.second.DefaultCastAs(LogicalType::BOOLEAN));
-			if (read_only) {
-				access_mode = AccessMode::READ_ONLY;
-			} else {
-				access_mode = AccessMode::READ_WRITE;
-			}
-			continue;
-		}
-
-		if (entry.first == "recovery_mode") {
-			// Extract the recovery mode.
-			auto mode_str = StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR));
-			recovery_mode = EnumUtil::FromString<RecoveryMode>(mode_str);
-			continue;
-		}
-
-		if (entry.first == "readwrite" || entry.first == "read_write") {
-			// Extract the write access mode.
-			auto read_write = BooleanValue::Get(entry.second.DefaultCastAs(LogicalType::BOOLEAN));
-			if (!read_write) {
-				access_mode = AccessMode::READ_ONLY;
-			} else {
-				access_mode = AccessMode::READ_WRITE;
-			}
-			continue;
-		}
-
-		if (entry.first == "type") {
-			// Extract the database type. Normalize case so that
-			// `TYPE sqlite` and `TYPE 'SQLite'` are equivalent.
-			// `TYPE sqlite` and `TYPE 'sqlite3'` are NOT equivalent, aliasing to be applied on comparison
-			db_type = StringUtil::Lower(StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR)));
-			continue;
-		}
-
-		if (entry.first == "default_table") {
-			default_table = QualifiedName::Parse(StringValue::Get(entry.second.DefaultCastAs(LogicalType::VARCHAR)));
-			continue;
-		}
-
-		if (entry.first == "hidden") {
-			auto is_hidden = BooleanValue::Get(entry.second.DefaultCastAs(LogicalType::BOOLEAN));
-			if (is_hidden) {
-				visibility = AttachVisibility::HIDDEN;
-			}
-			continue;
-		}
-
-		if (entry.first == "vacuum_rebuild_indexes") {
-			const auto threshold = UBigIntValue::Get(entry.second.DefaultCastAs(LogicalType::UBIGINT));
-			try {
-				vacuum_rebuild_indexes_threshold = threshold;
-			} catch (InternalException &e) {
-				throw InvalidInputException("Invalid setting for vacuum_rebuild_indexes: %d (valid range is 0 - %d)",
-				                            threshold,
-				                            UBigIntValue::Get(Value::MaximumValue(LogicalType::UBIGINT)) - 1);
-			}
-			continue;
-		}
-		options.emplace(entry.first, entry.second);
+		ApplyOption(entry.first, entry.second);
 	}
+}
+
+void AttachOptions::ApplyOption(const string &key, const Value &value) {
+	if (key == "readonly" || key == "read_only") {
+		// Extract the read access mode.
+		auto read_only = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
+		if (read_only) {
+			access_mode = AccessMode::READ_ONLY;
+		} else {
+			access_mode = AccessMode::READ_WRITE;
+		}
+		return;
+	}
+
+	if (key == "recovery_mode") {
+		// Extract the recovery mode.
+		auto mode_str = StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR));
+		recovery_mode = EnumUtil::FromString<RecoveryMode>(mode_str);
+		return;
+	}
+
+	if (key == "readwrite" || key == "read_write") {
+		// Extract the write access mode.
+		auto read_write = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
+		if (!read_write) {
+			access_mode = AccessMode::READ_ONLY;
+		} else {
+			access_mode = AccessMode::READ_WRITE;
+		}
+		return;
+	}
+
+	if (key == "type") {
+		// Extract the database type. Normalize case so that
+		// `TYPE sqlite` and `TYPE 'SQLite'` are equivalent.
+		// `TYPE sqlite` and `TYPE 'sqlite3'` are NOT equivalent, aliasing to be applied on comparison
+		db_type = StringUtil::Lower(StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR)));
+		return;
+	}
+
+	if (key == "default_table") {
+		default_table = QualifiedName::Parse(StringValue::Get(value.DefaultCastAs(LogicalType::VARCHAR)));
+		return;
+	}
+
+	if (key == "hidden") {
+		auto is_hidden = BooleanValue::Get(value.DefaultCastAs(LogicalType::BOOLEAN));
+		if (is_hidden) {
+			visibility = AttachVisibility::HIDDEN;
+		}
+		return;
+	}
+
+	if (key == "vacuum_rebuild_indexes") {
+		const auto threshold = UBigIntValue::Get(value.DefaultCastAs(LogicalType::UBIGINT));
+		try {
+			vacuum_rebuild_indexes_threshold = threshold;
+		} catch (InternalException &e) {
+			throw InvalidInputException("Invalid setting for vacuum_rebuild_indexes: %d (valid range is 0 - %d)",
+			                            threshold, UBigIntValue::Get(Value::MaximumValue(LogicalType::UBIGINT)) - 1);
+		}
+		return;
+	}
+	options[key] = value;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -17,16 +17,11 @@
 #include "duckdb/transaction/meta_transaction.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
-#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/storage/redirect_info.hpp"
 
 namespace duckdb {
-
-//! The maximum number of redirect hops followed when resolving a pointer file. Bounds chains and, together with
-//! cycle detection, guarantees termination.
-static constexpr idx_t MAX_REDIRECT_DEPTH = 8;
 
 //! Resolve a redirect target. A duckdb file target given as a relative path is resolved against the directory of
 //! the pointer file; absolute paths, URIs and remote files are used verbatim.
@@ -45,54 +40,54 @@ static string ResolveRedirectTarget(FileSystem &fs, const string &pointer_path, 
 	return fs.JoinPath(dir, target);
 }
 
-//! Rewrite an ATTACH in place so it opens the redirect target instead of the pointer file. Follows chains up to
-//! MAX_REDIRECT_DEPTH, detects cycles, gates targets behind enable_external_access, and merges stored options
-//! (user-supplied ATTACH options win). After this the normal type-resolution/late-open opens the final target.
+//! Rewrite an ATTACH in place so it opens the redirect target instead of the pointer file. Exactly one redirect is
+//! applied: the target must be a real database, not another pointer - chained redirects are rejected, which makes
+//! cycles impossible and keeps option-merging and provenance unambiguous. Gates the target behind
+//! enable_external_access and merges stored options (user-supplied ATTACH options win). After this the normal
+//! type-resolution/late-open opens the target.
 static void ApplyRedirects(ClientContext &context, FileSystem &fs, AttachInfo &info, AttachOptions &options,
-                           RedirectInfo redirect) {
+                           const RedirectInfo &redirect) {
 	auto &config = DBConfig::GetConfig(context);
-	unordered_set<string> visited;
-	visited.insert(info.path);
-	idx_t depth = 0;
-	while (redirect.is_redirect) {
-		if (++depth > MAX_REDIRECT_DEPTH) {
+	const string pointer_path = info.path;
+	const bool duckdb_target = redirect.type.empty() || StringUtil::CIEquals(redirect.type, "duckdb");
+	auto target = ResolveRedirectTarget(fs, pointer_path, redirect.target, duckdb_target);
+	if (target.empty()) {
+		throw InvalidInputException("ATTACH of \"%s\" has an empty redirect target", pointer_path);
+	}
+	if (target == pointer_path) {
+		throw InvalidInputException("ATTACH of \"%s\" redirects to itself", pointer_path);
+	}
+	if (!config.CanAccessFile(target, FileType::FILE_TYPE_REGULAR)) {
+		throw PermissionException(
+		    "ATTACH of \"%s\" redirects to \"%s\", which is not allowed because enable_external_access is disabled",
+		    pointer_path, target);
+	}
+
+	// Merge stored options - route each through AttachOptions so a core-consumed key (read_only, recovery_mode, ...)
+	// reaches its typed field instead of surviving as an unrecognized leftover. User-supplied ATTACH options win, so
+	// skip any key the user provided explicitly.
+	for (auto &option : redirect.options) {
+		if (info.options.find(option.key) != info.options.end()) {
+			continue;
+		}
+		options.ApplyOption(option.key, Value(option.value));
+	}
+
+	// Rewrite the attach to point at the target and drop the pointer file's now-stale prefetched header.
+	info.path = target;
+	options.db_type = duckdb_target ? "" : redirect.type;
+	options.prefetched = PrefetchedFileData();
+
+	// Only one redirect is allowed. For a duckdb target, re-read its header (which also refills the prefetch reused
+	// by the late open); if the target is itself a pointer, reject rather than following a chain.
+	if (duckdb_target) {
+		RedirectInfo target_redirect;
+		DBPathAndType::CheckMagicBytes(context, fs, info.path, options.db_type, &options.prefetched, &target_redirect);
+		if (target_redirect.is_redirect) {
 			throw InvalidInputException(
-			    "ATTACH of \"%s\" exceeded the maximum redirect depth of %llu (possible redirect cycle)", info.path,
-			    MAX_REDIRECT_DEPTH);
-		}
-		const bool duckdb_target = redirect.type.empty() || StringUtil::CIEquals(redirect.type, "duckdb");
-		auto target = ResolveRedirectTarget(fs, info.path, redirect.target, duckdb_target);
-		if (target.empty()) {
-			throw InvalidInputException("ATTACH of \"%s\" has an empty redirect target", info.path);
-		}
-		if (!visited.insert(target).second) {
-			throw InvalidInputException("ATTACH of \"%s\" forms a redirect cycle at target \"%s\"", info.path, target);
-		}
-		if (!config.CanAccessFile(target, FileType::FILE_TYPE_REGULAR)) {
-			throw PermissionException(
-			    "ATTACH of \"%s\" redirects to \"%s\", which is not allowed because enable_external_access is disabled",
-			    info.path, target);
-		}
-
-		// Merge stored options - route each through AttachOptions so a core-consumed key (read_only, recovery_mode,
-		// ...) reaches its typed field instead of surviving as an unrecognized leftover. User-supplied ATTACH options
-		// win, so skip any key the user provided explicitly.
-		for (auto &option : redirect.options) {
-			if (info.options.find(option.key) != info.options.end()) {
-				continue;
-			}
-			options.ApplyOption(option.key, Value(option.value));
-		}
-
-		// Rewrite the attach to point at the target and drop the pointer file's now-stale prefetched header.
-		info.path = target;
-		options.db_type = duckdb_target ? "" : redirect.type;
-		options.prefetched = PrefetchedFileData();
-
-		// Follow another hop only if the target is itself a duckdb file (re-reads its header, refills prefetch).
-		redirect = RedirectInfo();
-		if (duckdb_target) {
-			DBPathAndType::CheckMagicBytes(context, fs, info.path, options.db_type, &options.prefetched, &redirect);
+			    "ATTACH of \"%s\" redirects to \"%s\", which is itself a redirect pointer; chained redirects are not "
+			    "supported",
+			    pointer_path, target);
 		}
 	}
 }
@@ -502,7 +497,7 @@ void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, 
 		DBPathAndType::CheckMagicBytes(context, fs, info.path, options.db_type, &options.prefetched, &redirect);
 		if (redirect.is_redirect) {
 			// Reinterpret the ATTACH to open the redirect target instead of the pointer file.
-			ApplyRedirects(context, fs, info, options, std::move(redirect));
+			ApplyRedirects(context, fs, info, options, redirect);
 		}
 	}
 

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -15,8 +15,82 @@
 #include "duckdb/transaction/duck_transaction_manager.hpp"
 #include "duckdb/common/enums/on_entry_not_found.hpp"
 #include "duckdb/transaction/meta_transaction.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/unordered_set.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/parser/parsed_data/attach_info.hpp"
+#include "duckdb/storage/redirect_info.hpp"
 
 namespace duckdb {
+
+//! The maximum number of redirect hops followed when resolving a pointer file. Bounds chains and, together with
+//! cycle detection, guarantees termination.
+static constexpr idx_t MAX_REDIRECT_DEPTH = 8;
+
+//! Resolve a redirect target. A duckdb file target given as a relative path is resolved against the directory of
+//! the pointer file; absolute paths, URIs and remote files are used verbatim.
+static string ResolveRedirectTarget(FileSystem &fs, const string &pointer_path, const string &target,
+                                    bool duckdb_target) {
+	if (!duckdb_target) {
+		return target;
+	}
+	if (fs.IsPathAbsolute(target) || FileSystem::IsRemoteFile(target) || StringUtil::Contains(target, "://")) {
+		return target;
+	}
+	auto dir = StringUtil::GetFilePath(pointer_path);
+	if (dir.empty()) {
+		return target;
+	}
+	return fs.JoinPath(dir, target);
+}
+
+//! Rewrite an ATTACH in place so it opens the redirect target instead of the pointer file. Follows chains up to
+//! MAX_REDIRECT_DEPTH, detects cycles, gates targets behind enable_external_access, and merges stored options
+//! (user-supplied ATTACH options win). After this the normal type-resolution/late-open opens the final target.
+static void ApplyRedirects(ClientContext &context, FileSystem &fs, AttachInfo &info, AttachOptions &options,
+                           RedirectInfo redirect) {
+	auto &config = DBConfig::GetConfig(context);
+	unordered_set<string> visited;
+	visited.insert(info.path);
+	idx_t depth = 0;
+	while (redirect.is_redirect) {
+		if (++depth > MAX_REDIRECT_DEPTH) {
+			throw InvalidInputException(
+			    "ATTACH of \"%s\" exceeded the maximum redirect depth of %llu (possible redirect cycle)", info.path,
+			    MAX_REDIRECT_DEPTH);
+		}
+		const bool duckdb_target = redirect.type.empty() || StringUtil::CIEquals(redirect.type, "duckdb");
+		auto target = ResolveRedirectTarget(fs, info.path, redirect.target, duckdb_target);
+		if (target.empty()) {
+			throw InvalidInputException("ATTACH of \"%s\" has an empty redirect target", info.path);
+		}
+		if (!visited.insert(target).second) {
+			throw InvalidInputException("ATTACH of \"%s\" forms a redirect cycle at target \"%s\"", info.path, target);
+		}
+		if (!config.CanAccessFile(target, FileType::FILE_TYPE_REGULAR)) {
+			throw PermissionException(
+			    "ATTACH of \"%s\" redirects to \"%s\", which is not allowed because enable_external_access is disabled",
+			    info.path, target);
+		}
+
+		// Merge stored options into the options the storage extension reads - user-supplied options win.
+		for (auto &option : redirect.options) {
+			options.options.emplace(option.key, Value(option.value));
+		}
+
+		// Rewrite the attach to point at the target and drop the pointer file's now-stale prefetched header.
+		info.path = target;
+		options.db_type = duckdb_target ? "" : redirect.type;
+		options.prefetched = PrefetchedFileData();
+
+		// Follow another hop only if the target is itself a duckdb file (re-reads its header, refills prefetch).
+		redirect = RedirectInfo();
+		if (duckdb_target) {
+			DBPathAndType::CheckMagicBytes(context, fs, info.path, options.db_type, &options.prefetched, &redirect);
+		}
+	}
+}
 
 // Oids are started at 20000 to avoid colliding with Postgres builtin types, which end at 16383:
 // https://github.com/postgres/postgres/blob/db93988ab0e78396f2ed9e96c826ff988d12b9f2/src/include/access/transam.h#L156-L197
@@ -390,7 +464,13 @@ void DatabaseManager::GetDatabaseType(ClientContext &context, AttachInfo &info, 
 	if (options.db_type.empty()) {
 		auto &fs = FileSystem::GetFileSystem(context);
 		// Prefetch the header for a DuckDB file, reused when opening it (see AttachOptions::prefetched).
-		DBPathAndType::CheckMagicBytes(context, fs, info.path, options.db_type, &options.prefetched);
+		// A redirect record (pointer file), if present, is parsed from the same bytes.
+		RedirectInfo redirect;
+		DBPathAndType::CheckMagicBytes(context, fs, info.path, options.db_type, &options.prefetched, &redirect);
+		if (redirect.is_redirect) {
+			// Reinterpret the ATTACH to open the redirect target instead of the pointer file.
+			ApplyRedirects(context, fs, info, options, std::move(redirect));
+		}
 	}
 
 	if (options.db_type.empty()) {

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -74,9 +74,14 @@ static void ApplyRedirects(ClientContext &context, FileSystem &fs, AttachInfo &i
 			    info.path, target);
 		}
 
-		// Merge stored options into the options the storage extension reads - user-supplied options win.
+		// Merge stored options - route each through AttachOptions so a core-consumed key (read_only, recovery_mode,
+		// ...) reaches its typed field instead of surviving as an unrecognized leftover. User-supplied ATTACH options
+		// win, so skip any key the user provided explicitly.
 		for (auto &option : redirect.options) {
-			options.options.emplace(option.key, Value(option.value));
+			if (info.options.find(option.key) != info.options.end()) {
+				continue;
+			}
+			options.ApplyOption(option.key, Value(option.value));
 		}
 
 		// Rewrite the attach to point at the target and drop the pointer file's now-stale prefetched header.

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -266,7 +266,9 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 	auto &config = DBConfig::GetConfig(context);
 	auto pre_redirect_path = info.path;
 	GetDatabaseType(context, info, config, options);
-	if (requires_tracking_attaches && options.db_type.empty() && info.path != pre_redirect_path) {
+	// GetDatabaseType only rewrites info.path when a redirect was applied, so this detects a redirected attach.
+	const bool redirected = info.path != pre_redirect_path;
+	if (requires_tracking_attaches && options.db_type.empty() && redirected) {
 		// A redirect rewrote the path to a DuckDB target. The duplicate-open guard was registered against the
 		// pointer path, not the target - re-register the (canonicalized) target so opening the same database
 		// directly and via a pointer, or via two pointers, still conflicts.
@@ -305,6 +307,11 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 	// now create the attached database
 	auto &db = DatabaseInstance::GetDatabase(context);
 	auto attached_db = db.CreateAttachedDatabase(context, info, options);
+
+	if (redirected) {
+		// Surface the pointer file this attach was redirected from; the `path` column shows the resolved target.
+		attached_db->tags.insert("pointed_from", pre_redirect_path);
+	}
 
 	if (default_database.empty()) {
 		default_database = attached_db->GetName();

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -259,7 +259,28 @@ shared_ptr<AttachedDatabase> DatabaseManager::AttachDatabase(ClientContext &cont
 		timer.EndTimer();
 	}
 	auto &config = DBConfig::GetConfig(context);
+	auto pre_redirect_path = info.path;
 	GetDatabaseType(context, info, config, options);
+	if (requires_tracking_attaches && options.db_type.empty() && info.path != pre_redirect_path) {
+		// A redirect rewrote the path to a DuckDB target. The duplicate-open guard was registered against the
+		// pointer path, not the target - re-register the (canonicalized) target so opening the same database
+		// directly and via a pointer, or via two pointers, still conflicts.
+		auto &fs = FileSystem::GetFileSystem(context);
+		info.path = fs.CanonicalizePath(info.path);
+		options.stored_database_path.reset();
+		if (InsertDatabasePath(info, options) == InsertDatabasePathResult::ALREADY_EXISTS) {
+			// A concurrent attach of the same target under the same name won the race - return it.
+			auto &meta_transaction = MetaTransaction::Get(context);
+			if (auto existing_db = meta_transaction.GetReferencedDatabaseOwning(info.name)) {
+				return existing_db;
+			}
+			lock_guard<mutex> guard(databases_lock);
+			auto entry = databases.find(info.name);
+			if (entry != databases.end()) {
+				return entry->second;
+			}
+		}
+	}
 	if (!options.db_type.empty()) {
 		// we only need to prevent duplicate opening of DuckDB files
 		// if this is not a DuckDB file but e.g. a CSV or Parquet file, we don't need to do this duplicate protection

--- a/src/main/database_path_and_type.cpp
+++ b/src/main/database_path_and_type.cpp
@@ -20,9 +20,10 @@ void DBPathAndType::ExtractExtensionPrefix(string &path, string &db_type) {
 }
 
 void DBPathAndType::CheckMagicBytes(QueryContext context, FileSystem &fs, string &path, string &db_type,
-                                    optional_ptr<PrefetchedFileData> out_prefetch) {
+                                    optional_ptr<PrefetchedFileData> out_prefetch,
+                                    optional_ptr<RedirectInfo> out_redirect) {
 	// if there isn't - check the magic bytes of the file (if any)
-	auto file_type = MagicBytes::CheckMagicBytes(context, fs, path, out_prefetch);
+	auto file_type = MagicBytes::CheckMagicBytes(context, fs, path, out_prefetch, out_redirect);
 	db_type = string();
 	switch (file_type) {
 	case DataFileType::SQLITE_FILE:
@@ -44,7 +45,8 @@ void DBPathAndType::CheckMagicBytes(QueryContext context, FileSystem &fs, string
 }
 
 void DBPathAndType::ResolveDatabaseType(FileSystem &fs, string &path, string &db_type,
-                                        optional_ptr<PrefetchedFileData> out_prefetch) {
+                                        optional_ptr<PrefetchedFileData> out_prefetch,
+                                        optional_ptr<RedirectInfo> out_redirect) {
 	if (!db_type.empty()) {
 		// database type specified explicitly - no need to check
 		return;
@@ -56,7 +58,7 @@ void DBPathAndType::ResolveDatabaseType(FileSystem &fs, string &path, string &db
 		return;
 	}
 	// check database type by reading the magic bytes of a file
-	DBPathAndType::CheckMagicBytes(QueryContext(), fs, path, db_type, out_prefetch);
+	DBPathAndType::CheckMagicBytes(QueryContext(), fs, path, db_type, out_prefetch, out_redirect);
 }
 
 } // namespace duckdb

--- a/src/storage/magic_bytes.cpp
+++ b/src/storage/magic_bytes.cpp
@@ -2,8 +2,10 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/prefetched_file_data.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/storage/storage_info.hpp"
+#include "duckdb/storage/redirect_info.hpp"
 
 #include <cstring>
 
@@ -26,8 +28,29 @@ static DataFileType ClassifyMagicBytes(const char *buffer) {
 	return DataFileType::UNKNOWN_FILE;
 }
 
+//! Parse a redirect record from the already-prefetched header bytes. A malformed or partial header simply
+//! yields no redirect - the normal storage open path surfaces genuine corruption. Encrypted databases are
+//! skipped: their redirect record would be ciphertext, and the key is not available during detection.
+static void ParseRedirect(char *buffer, idx_t buffer_size, RedirectInfo &out_redirect) {
+	if (buffer_size <= MainHeader::MAGIC_BYTE_OFFSET) {
+		return;
+	}
+	try {
+		MemoryStream stream(reinterpret_cast<data_ptr_t>(buffer) + MainHeader::MAGIC_BYTE_OFFSET,
+		                    buffer_size - MainHeader::MAGIC_BYTE_OFFSET);
+		// Skip the storage-version gate so a poisoned pointer file is still detected as a redirect.
+		auto header = MainHeader::Read(stream, false);
+		if (!header.IsEncrypted() && header.IsRedirect()) {
+			out_redirect = std::move(header.redirect);
+		}
+	} catch (const std::exception &) {
+		// Not a readable redirect record - leave out_redirect empty.
+	}
+}
+
 DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, const string &path,
-                                         optional_ptr<PrefetchedFileData> out_prefetch) {
+                                         optional_ptr<PrefetchedFileData> out_prefetch,
+                                         optional_ptr<RedirectInfo> out_redirect) {
 	if (path.empty() || path == IN_MEMORY_PATH) {
 		return DataFileType::DUCKDB_FILE;
 	}
@@ -40,7 +63,9 @@ DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, c
 	}
 
 	// Zero-initialized so a short read at EOF still yields a well-defined (non-matching) classification.
-	const idx_t read_size = out_prefetch ? HEADER_PREFETCH_SIZE : MAGIC_BYTES_READ_SIZE;
+	// Reading the full header region is needed both to prefetch and to parse a redirect record.
+	const bool read_full_header = out_prefetch || out_redirect;
+	const idx_t read_size = read_full_header ? HEADER_PREFETCH_SIZE : MAGIC_BYTES_READ_SIZE;
 	auto buffer = make_unsafe_uniq_array<char>(read_size);
 	memset(buffer.get(), 0, read_size);
 	const idx_t to_read = MinValue<idx_t>(read_size, handle->GetFileSize());
@@ -50,9 +75,15 @@ DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, c
 
 	auto file_type = ClassifyMagicBytes(buffer.get());
 
-	// Hand the prefetched header bytes to the caller for DuckDB files. Only the `to_read` valid bytes are kept.
-	if (out_prefetch && file_type == DataFileType::DUCKDB_FILE) {
-		out_prefetch->header = make_shared_ptr<const string>(buffer.get(), to_read);
+	if (file_type == DataFileType::DUCKDB_FILE) {
+		// Hand the prefetched header bytes to the caller. Only the `to_read` valid bytes are kept.
+		if (out_prefetch) {
+			out_prefetch->header = make_shared_ptr<const string>(buffer.get(), to_read);
+		}
+		// Parse a redirect record (if any) from the same bytes - no extra I/O.
+		if (out_redirect) {
+			ParseRedirect(buffer.get(), to_read, *out_redirect);
+		}
 	}
 	return file_type;
 }

--- a/src/storage/magic_bytes.cpp
+++ b/src/storage/magic_bytes.cpp
@@ -1,4 +1,6 @@
 #include "duckdb/storage/magic_bytes.hpp"
+#include "duckdb/common/checksum.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/prefetched_file_data.hpp"
@@ -28,23 +30,72 @@ static DataFileType ClassifyMagicBytes(const char *buffer) {
 	return DataFileType::UNKNOWN_FILE;
 }
 
-//! Parse a redirect record from the already-prefetched header bytes. A malformed or partial header simply
-//! yields no redirect - the normal storage open path surfaces genuine corruption. Encrypted databases are
-//! skipped: their redirect record would be ciphertext, and the key is not available during detection.
-static void ParseRedirect(char *buffer, idx_t buffer_size, RedirectInfo &out_redirect) {
-	if (buffer_size <= MainHeader::MAGIC_BYTE_OFFSET) {
+//! Verify a header block's self-checksum: the first 8 bytes hold the checksum over the remaining data region.
+//! The main header and (unencrypted) database headers are plaintext and use this same layout.
+static bool VerifyHeaderBlockChecksum(const_data_ptr_t block_start) {
+	auto stored = Load<uint64_t>(block_start);
+	auto computed =
+	    Checksum(block_start + MainHeader::MAGIC_BYTE_OFFSET, Storage::FILE_HEADER_SIZE - MainHeader::MAGIC_BYTE_OFFSET);
+	return stored == computed;
+}
+
+//! Parse a redirect record from the already-prefetched header bytes. The MainHeader (block 0) carries the redirect
+//! flag; the record itself lives in the DatabaseHeaders (blocks 1/2), the active one chosen by iteration count -
+//! mirroring how a re-point atomically swaps the active slot. Every block is checksum-verified before it is trusted,
+//! so a single corrupted byte cannot silently attach a wrong target. A malformed or partial header yields no
+//! redirect (the normal open path surfaces genuine corruption); a redirect-flagged file with no readable record is
+//! reported as corrupt. Encrypted databases are skipped: their record would be ciphertext, and the key is not
+//! available during detection.
+static void ParseRedirect(const string &path, char *buffer, idx_t buffer_size, RedirectInfo &out_redirect) {
+	// The record lives in the DatabaseHeaders, so the full 3-block header region must have been read.
+	if (buffer_size < 3 * Storage::FILE_HEADER_SIZE) {
 		return;
 	}
+	auto data = reinterpret_cast<data_ptr_t>(buffer);
+
+	// Only trust the redirect flag if the MainHeader block itself is intact; otherwise let the normal open path
+	// report the corruption.
+	if (!VerifyHeaderBlockChecksum(data)) {
+		return;
+	}
+	MainHeader main_header {};
 	try {
-		MemoryStream stream(reinterpret_cast<data_ptr_t>(buffer) + MainHeader::MAGIC_BYTE_OFFSET,
-		                    buffer_size - MainHeader::MAGIC_BYTE_OFFSET);
+		MemoryStream main_stream(data + MainHeader::MAGIC_BYTE_OFFSET,
+		                         Storage::FILE_HEADER_SIZE - MainHeader::MAGIC_BYTE_OFFSET);
 		// Skip the storage-version gate so a poisoned pointer file is still detected as a redirect.
-		auto header = MainHeader::Read(stream, false);
-		if (!header.IsEncrypted() && header.IsRedirect()) {
-			out_redirect = std::move(header.redirect);
-		}
+		main_header = MainHeader::Read(main_stream, false);
 	} catch (const std::exception &) {
-		// Not a readable redirect record - leave out_redirect empty.
+		return;
+	}
+	if (main_header.IsEncrypted() || !main_header.IsRedirect()) {
+		return;
+	}
+
+	// Pick the valid slot with the highest iteration - a torn re-point leaves the older slot intact as a fallback.
+	bool found = false;
+	uint64_t best_iteration = 0;
+	for (idx_t slot = 1; slot <= 2; slot++) {
+		auto block_start = data + slot * Storage::FILE_HEADER_SIZE;
+		if (!VerifyHeaderBlockChecksum(block_start)) {
+			continue;
+		}
+		try {
+			MemoryStream db_stream(block_start + MainHeader::MAGIC_BYTE_OFFSET,
+			                       Storage::FILE_HEADER_SIZE - MainHeader::MAGIC_BYTE_OFFSET);
+			auto db_header = DatabaseHeader::Read(main_header, db_stream);
+			if (db_header.redirect.is_redirect && (!found || db_header.iteration >= best_iteration)) {
+				out_redirect = std::move(db_header.redirect);
+				best_iteration = db_header.iteration;
+				found = true;
+			}
+		} catch (const std::exception &) {
+			// A checksum-valid slot with an unreadable record - skip it; the other slot may still be usable.
+		}
+	}
+	if (!found) {
+		throw IOException(
+		    "Corrupt redirect pointer file \"%s\": the redirect flag is set but no valid redirect record was found",
+		    path);
 	}
 }
 
@@ -82,7 +133,7 @@ DataFileType MagicBytes::CheckMagicBytes(QueryContext context, FileSystem &fs, c
 		}
 		// Parse a redirect record (if any) from the same bytes - no extra I/O.
 		if (out_redirect) {
-			ParseRedirect(buffer.get(), to_read, *out_redirect);
+			ParseRedirect(path, buffer.get(), to_read, *out_redirect);
 		}
 	}
 	return file_type;

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -250,18 +250,6 @@ void MainHeader::Write(WriteStream &ser) {
 	SerializeEncryptionMetadata(ser, encrypted_canary, encryption_enabled);
 	SerializeIV(ser, canary_iv, encryption_enabled);
 	SerializeTag(ser, canary_tag, encryption_enabled);
-
-	// Append the redirect record when this file is a pointer. It is bounded so it always fits the 4KiB block.
-	if (IsRedirect()) {
-		MemoryStream record_stream;
-		redirect.Serialize(record_stream);
-		if (record_stream.GetPosition() > RedirectInfo::MAX_RECORD_SIZE) {
-			throw InvalidInputException(
-			    "The redirect record is %llu bytes, which exceeds the maximum redirect record size of %llu",
-			    record_stream.GetPosition(), RedirectInfo::MAX_RECORD_SIZE);
-		}
-		ser.WriteData(record_stream.GetData(), record_stream.GetPosition());
-	}
 }
 
 void MainHeader::CheckMagicBytes(QueryContext context, FileHandle &handle) {
@@ -335,11 +323,6 @@ MainHeader MainHeader::Read(ReadStream &source, bool check_version) {
 	DeserializeEncryptionData(source, header.canary_iv, MainHeader::AES_NONCE_LEN);
 	DeserializeEncryptionData(source, header.canary_tag, MainHeader::AES_TAG_LEN);
 
-	// The redirect record is appended after the fixed fields when the redirect flag is set.
-	if (header.IsRedirect()) {
-		header.redirect = RedirectInfo::Deserialize(source);
-	}
-
 	return header;
 }
 
@@ -357,6 +340,18 @@ void DatabaseHeader::Write(WriteStream &ser) {
 		ser.Write<idx_t>(ser_version);
 	} else {
 		ser.Write<idx_t>(static_cast<idx_t>(storage_compatibility));
+	}
+
+	// Append the redirect record when this file is a pointer. It is bounded so it always fits the 4KiB block.
+	if (redirect.is_redirect) {
+		MemoryStream record_stream;
+		redirect.Serialize(record_stream);
+		if (record_stream.GetPosition() > RedirectInfo::MAX_RECORD_SIZE) {
+			throw InvalidInputException(
+			    "The redirect record is %llu bytes, which exceeds the maximum redirect record size of %llu",
+			    record_stream.GetPosition(), RedirectInfo::MAX_RECORD_SIZE);
+		}
+		ser.WriteData(record_stream.GetData(), record_stream.GetPosition());
 	}
 }
 
@@ -442,6 +437,11 @@ DatabaseHeader DatabaseHeader::Read(const MainHeader &main_header, ReadStream &s
 	auto database_header_storage_version = static_cast<StorageVersion>(h_storage_version);
 	SetStorageVersionInDatabaseHeader(header, static_cast<StorageVersion>(main_header.version_number),
 	                                  database_header_storage_version);
+
+	// The redirect record is appended after the fixed fields when the MainHeader redirect flag is set.
+	if (main_header.IsRedirect()) {
+		header.redirect = RedirectInfo::Deserialize(source);
+	}
 
 	return header;
 }

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -30,6 +30,62 @@ const char MainHeader::MAGIC_BYTES[] = "DUCK";
 const char MainHeader::CANARY[] = "DUCKKEY";
 static constexpr idx_t ENCRYPTION_METADATA_LEN = 8;
 
+static void WriteRedirectString(WriteStream &ser, const string &str) {
+	if (str.size() > RedirectInfo::MAX_RECORD_SIZE) {
+		throw InvalidInputException("Redirect string of length %llu exceeds the maximum redirect record size of %llu",
+		                            str.size(), RedirectInfo::MAX_RECORD_SIZE);
+	}
+	ser.Write<uint32_t>(NumericCast<uint32_t>(str.size()));
+	ser.WriteData(const_data_ptr_cast(str.c_str()), str.size());
+}
+
+static string ReadRedirectString(ReadStream &source) {
+	auto len = source.Read<uint32_t>();
+	if (len > RedirectInfo::MAX_RECORD_SIZE) {
+		throw IOException("Corrupt redirect record: string length %u exceeds the maximum redirect record size of %llu",
+		                  len, RedirectInfo::MAX_RECORD_SIZE);
+	}
+	string result(len, '\0');
+	if (len > 0) {
+		source.ReadData(data_ptr_cast(&result[0]), len);
+	}
+	return result;
+}
+
+void RedirectInfo::Serialize(WriteStream &ser) const {
+	ser.Write<uint8_t>(version);
+	WriteRedirectString(ser, type);
+	WriteRedirectString(ser, target);
+	ser.Write<uint32_t>(NumericCast<uint32_t>(options.size()));
+	for (auto &option : options) {
+		WriteRedirectString(ser, option.key);
+		WriteRedirectString(ser, option.value);
+	}
+}
+
+RedirectInfo RedirectInfo::Deserialize(ReadStream &source) {
+	RedirectInfo result;
+	result.is_redirect = true;
+	result.version = source.Read<uint8_t>();
+	if (result.version != RedirectInfo::CURRENT_VERSION) {
+		throw IOException("Unsupported redirect record version %d - this DuckDB build only understands version %d",
+		                  result.version, RedirectInfo::CURRENT_VERSION);
+	}
+	result.type = ReadRedirectString(source);
+	result.target = ReadRedirectString(source);
+	auto option_count = source.Read<uint32_t>();
+	if (option_count > RedirectInfo::MAX_RECORD_SIZE) {
+		throw IOException("Corrupt redirect record: option count %u is implausibly large", option_count);
+	}
+	for (uint32_t i = 0; i < option_count; i++) {
+		RedirectOption option;
+		option.key = ReadRedirectString(source);
+		option.value = ReadRedirectString(source);
+		result.options.push_back(std::move(option));
+	}
+	return result;
+}
+
 void SerializeVersionNumber(WriteStream &ser, const string &version_str) {
 	data_t version[MainHeader::MAX_VERSION_SIZE];
 	memset(version, 0, MainHeader::MAX_VERSION_SIZE);
@@ -194,6 +250,18 @@ void MainHeader::Write(WriteStream &ser) {
 	SerializeEncryptionMetadata(ser, encrypted_canary, encryption_enabled);
 	SerializeIV(ser, canary_iv, encryption_enabled);
 	SerializeTag(ser, canary_tag, encryption_enabled);
+
+	// Append the redirect record when this file is a pointer. It is bounded so it always fits the 4KiB block.
+	if (IsRedirect()) {
+		MemoryStream record_stream;
+		redirect.Serialize(record_stream);
+		if (record_stream.GetPosition() > RedirectInfo::MAX_RECORD_SIZE) {
+			throw InvalidInputException(
+			    "The redirect record is %llu bytes, which exceeds the maximum redirect record size of %llu",
+			    record_stream.GetPosition(), RedirectInfo::MAX_RECORD_SIZE);
+		}
+		ser.WriteData(record_stream.GetData(), record_stream.GetPosition());
+	}
 }
 
 void MainHeader::CheckMagicBytes(QueryContext context, FileHandle &handle) {
@@ -214,7 +282,7 @@ void MainHeader::CheckMagicBytes(MemoryMappedFile &handle) {
 	}
 }
 
-MainHeader MainHeader::Read(ReadStream &source) {
+MainHeader MainHeader::Read(ReadStream &source, bool check_version) {
 	data_t magic_bytes[MAGIC_BYTE_SIZE];
 
 	MainHeader header;
@@ -225,7 +293,10 @@ MainHeader MainHeader::Read(ReadStream &source) {
 
 	header.version_number = source.Read<idx_t>();
 
-	if (static_cast<StorageVersion>(header.version_number) == DEPRECATED_VERSION_NUMBER) {
+	if (!check_version) {
+		// Skip the storage-version gate: used for redirect detection, where a pointer file may carry a poisoned
+		// storage version that must not throw before the redirect is applied.
+	} else if (static_cast<StorageVersion>(header.version_number) == DEPRECATED_VERSION_NUMBER) {
 		// if the version number in the main header is deprecated, then we just ignore the main header version number
 		// TODO: if we are confident, we can remove the check below
 	} else if (header.version_number < VERSION_NUMBER_LOWER || header.version_number > VERSION_NUMBER_UPPER) {
@@ -263,6 +334,11 @@ MainHeader MainHeader::Read(ReadStream &source) {
 	DeserializeEncryptionData(source, header.encrypted_canary, MainHeader::CANARY_BYTE_SIZE);
 	DeserializeEncryptionData(source, header.canary_iv, MainHeader::AES_NONCE_LEN);
 	DeserializeEncryptionData(source, header.canary_tag, MainHeader::AES_TAG_LEN);
+
+	// The redirect record is appended after the fixed fields when the redirect flag is set.
+	if (header.IsRedirect()) {
+		header.redirect = RedirectInfo::Deserialize(source);
+	}
 
 	return header;
 }

--- a/src/storage/single_file_block_manager.cpp
+++ b/src/storage/single_file_block_manager.cpp
@@ -711,6 +711,15 @@ void SingleFileBlockManager::LoadExistingDatabase(QueryContext context) {
 	}
 
 	MainHeader main_header = DeserializeMainHeader(header_buffer.GetDataMutable() - delta);
+	if (main_header.IsRedirect()) {
+		// A redirect pointer file must never be opened as an ordinary database: doing so would expose (or let a
+		// write clobber) a file that only carries a pointer to its real target. Detection normally diverts the
+		// ATTACH to the target; reaching here means detection was bypassed (e.g. an explicit TYPE duckdb).
+		throw IOException(
+		    "Cannot open \"%s\" as an ordinary database: it is a redirect pointer file. Attach it without an "
+		    "explicit TYPE so the redirect is followed to its target.",
+		    path);
+	}
 	memcpy(options.db_identifier, main_header.GetDBIdentifier(), MainHeader::DB_IDENTIFIER_LEN);
 
 	if (!main_header.IsEncrypted() && options.encryption_options.encryption_enabled) {

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -46,7 +46,8 @@ set(TEST_API_OBJECTS
     test_object_cache.cpp
     test_partial_executor.cpp
     test_buffer_pool_eviction.cpp
-    test_block_allocator_tls.cpp)
+    test_block_allocator_tls.cpp
+    test_redirect_header.cpp)
 
 if(NOT WIN32)
   set(TEST_API_OBJECTS ${TEST_API_OBJECTS} test_read_only.cpp)

--- a/test/api/test_redirect_header.cpp
+++ b/test/api/test_redirect_header.cpp
@@ -1,0 +1,67 @@
+#include "catch.hpp"
+#include "test_helpers.hpp"
+#include "duckdb/storage/storage_info.hpp"
+#include "duckdb/storage/redirect_info.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+
+using namespace duckdb;
+
+TEST_CASE("MainHeader redirect record round-trips through Write/Read", "[api][redirect]") {
+	MainHeader header {};
+	header.version_number = static_cast<idx_t>(StorageVersion::V1_4_0);
+	header.SetRedirect();
+	REQUIRE(header.IsRedirect());
+
+	header.redirect.is_redirect = true;
+	header.redirect.type = "iceberg";
+	header.redirect.target = "s3://warehouse/table";
+	header.redirect.options.push_back({"catalog", "glue"});
+	header.redirect.options.push_back({"region", "us-east-1"});
+
+	MemoryStream stream;
+	header.Write(stream);
+	stream.Rewind();
+
+	auto read_header = MainHeader::Read(stream);
+	REQUIRE(read_header.IsRedirect());
+	REQUIRE(read_header.redirect.is_redirect);
+	REQUIRE(read_header.redirect.version == RedirectInfo::CURRENT_VERSION);
+	REQUIRE(read_header.redirect.type == "iceberg");
+	REQUIRE(read_header.redirect.target == "s3://warehouse/table");
+	REQUIRE(read_header.redirect.options.size() == 2);
+	REQUIRE(read_header.redirect.options[0].key == "catalog");
+	REQUIRE(read_header.redirect.options[0].value == "glue");
+	REQUIRE(read_header.redirect.options[1].key == "region");
+	REQUIRE(read_header.redirect.options[1].value == "us-east-1");
+}
+
+TEST_CASE("MainHeader without redirect flag reads no redirect record", "[api][redirect]") {
+	MainHeader header {};
+	header.version_number = static_cast<idx_t>(StorageVersion::V1_4_0);
+	REQUIRE(!header.IsRedirect());
+
+	MemoryStream stream;
+	header.Write(stream);
+	stream.Rewind();
+
+	auto read_header = MainHeader::Read(stream);
+	REQUIRE(!read_header.IsRedirect());
+	REQUIRE(!read_header.redirect.is_redirect);
+}
+
+TEST_CASE("Redirect record with no options round-trips", "[api][redirect]") {
+	RedirectInfo redirect;
+	redirect.is_redirect = true;
+	redirect.type = "";
+	redirect.target = "../moved/real.db";
+
+	MemoryStream stream;
+	redirect.Serialize(stream);
+	stream.Rewind();
+
+	auto read = RedirectInfo::Deserialize(stream);
+	REQUIRE(read.is_redirect);
+	REQUIRE(read.type.empty());
+	REQUIRE(read.target == "../moved/real.db");
+	REQUIRE(read.options.empty());
+}

--- a/test/api/test_redirect_header.cpp
+++ b/test/api/test_redirect_header.cpp
@@ -6,12 +6,16 @@
 
 using namespace duckdb;
 
-TEST_CASE("MainHeader redirect record round-trips through Write/Read", "[api][redirect]") {
-	MainHeader header {};
-	header.version_number = static_cast<idx_t>(StorageVersion::V1_4_0);
-	header.SetRedirect();
-	REQUIRE(header.IsRedirect());
+TEST_CASE("DatabaseHeader redirect record round-trips through Write/Read", "[api][redirect]") {
+	// The MainHeader carries only the redirect flag; the record itself lives in the DatabaseHeader.
+	MainHeader main_header {};
+	main_header.version_number = static_cast<idx_t>(StorageVersion::V2_0_0);
+	main_header.SetRedirect();
+	REQUIRE(main_header.IsRedirect());
 
+	DatabaseHeader header;
+	header.storage_compatibility = StorageVersion::V2_0_0;
+	header.iteration = 1;
 	header.redirect.is_redirect = true;
 	header.redirect.type = "iceberg";
 	header.redirect.target = "s3://warehouse/table";
@@ -22,8 +26,7 @@ TEST_CASE("MainHeader redirect record round-trips through Write/Read", "[api][re
 	header.Write(stream);
 	stream.Rewind();
 
-	auto read_header = MainHeader::Read(stream);
-	REQUIRE(read_header.IsRedirect());
+	auto read_header = DatabaseHeader::Read(main_header, stream);
 	REQUIRE(read_header.redirect.is_redirect);
 	REQUIRE(read_header.redirect.version == RedirectInfo::CURRENT_VERSION);
 	REQUIRE(read_header.redirect.type == "iceberg");
@@ -35,17 +38,20 @@ TEST_CASE("MainHeader redirect record round-trips through Write/Read", "[api][re
 	REQUIRE(read_header.redirect.options[1].value == "us-east-1");
 }
 
-TEST_CASE("MainHeader without redirect flag reads no redirect record", "[api][redirect]") {
-	MainHeader header {};
-	header.version_number = static_cast<idx_t>(StorageVersion::V1_4_0);
-	REQUIRE(!header.IsRedirect());
+TEST_CASE("DatabaseHeader without redirect flag reads no redirect record", "[api][redirect]") {
+	MainHeader main_header {};
+	main_header.version_number = static_cast<idx_t>(StorageVersion::V2_0_0);
+	REQUIRE(!main_header.IsRedirect());
+
+	DatabaseHeader header;
+	header.storage_compatibility = StorageVersion::V2_0_0;
+	header.iteration = 1;
 
 	MemoryStream stream;
 	header.Write(stream);
 	stream.Rewind();
 
-	auto read_header = MainHeader::Read(stream);
-	REQUIRE(!read_header.IsRedirect());
+	auto read_header = DatabaseHeader::Read(main_header, stream);
 	REQUIRE(!read_header.redirect.is_redirect);
 }
 

--- a/test/sql/attach/attach_redirect.test
+++ b/test/sql/attach/attach_redirect.test
@@ -118,3 +118,30 @@ statement error
 CALL redirect_create('{TEST_DIR}/redirect_real.db', 'somewhere', overwrite => true);
 ----
 <REGEX>:.*not a redirect pointer.*
+
+# F4: a core-consumed option (read_only) stored in a pointer is applied to the reinterpreted attach, not rejected
+# as an unknown option. The pointer opens its target read-only.
+statement ok
+CALL redirect_create('{TEST_DIR}/ro_ptr.db', 'redirect_real.db', options => MAP {'read_only': 'true'});
+
+statement ok
+ATTACH '{TEST_DIR}/ro_ptr.db' AS rodb;
+
+query I
+SELECT readonly FROM duckdb_databases WHERE database_name = 'rodb';
+----
+true
+
+statement error
+CREATE TABLE rodb.new_t(x INTEGER);
+----
+<REGEX>:.*read-only.*
+
+statement ok
+DETACH rodb;
+
+# a storage version below v2.0.0 is refused for a pointer file (older DuckDB must reject it, not open it empty)
+statement error
+CALL redirect_create('{TEST_DIR}/old_ptr.db', 'redirect_real.db', storage_version => 'v1.4.0');
+----
+<REGEX>:.*v2.0.0 or newer.*

--- a/test/sql/attach/attach_redirect.test
+++ b/test/sql/attach/attach_redirect.test
@@ -1,0 +1,94 @@
+# name: test/sql/attach/attach_redirect.test
+# description: Test redirect-on-attach: a pointer file reinterprets ATTACH to a different target database
+# group: [attach]
+
+# create a real database at the target location
+statement ok
+ATTACH '{TEST_DIR}/redirect_real.db' AS realdb;
+
+statement ok
+CREATE TABLE realdb.t(i INTEGER);
+
+statement ok
+INSERT INTO realdb.t VALUES (42), (43);
+
+statement ok
+DETACH realdb;
+
+# create a pointer file that redirects to the real database. A relative target is resolved against the
+# directory of the pointer file, so a bare filename points at a sibling database.
+statement ok
+CALL redirect_create('{TEST_DIR}/redirect_ptr.db', 'redirect_real.db');
+
+# attaching the pointer is reinterpreted to open the real database
+statement ok
+ATTACH '{TEST_DIR}/redirect_ptr.db' AS ptr;
+
+query I
+SELECT i FROM ptr.t ORDER BY i;
+----
+42
+43
+
+statement ok
+DETACH ptr;
+
+# re-attaching still works
+statement ok
+ATTACH '{TEST_DIR}/redirect_ptr.db' AS ptr2;
+
+query I
+SELECT count(*) FROM ptr2.t;
+----
+2
+
+statement ok
+DETACH ptr2;
+
+# a chained redirect (pointer -> pointer -> real) resolves through the chain
+statement ok
+CALL redirect_create('{TEST_DIR}/redirect_chain.db', 'redirect_ptr.db');
+
+statement ok
+ATTACH '{TEST_DIR}/redirect_chain.db' AS chained;
+
+query I
+SELECT count(*) FROM chained.t;
+----
+2
+
+statement ok
+DETACH chained;
+
+# an explicit TYPE on the ATTACH short-circuits redirect interpretation: the raw pointer file opens as an
+# ordinary (empty) duckdb database, proving the redirect was not applied.
+statement ok
+ATTACH '{TEST_DIR}/redirect_ptr.db' AS raw (TYPE duckdb);
+
+query I
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'raw';
+----
+0
+
+statement ok
+DETACH raw;
+
+# a redirect cycle is detected and rejected rather than looping forever
+statement ok
+CALL redirect_create('{TEST_DIR}/cycle_a.db', 'cycle_b.db');
+
+statement ok
+CALL redirect_create('{TEST_DIR}/cycle_b.db', 'cycle_a.db');
+
+statement error
+ATTACH '{TEST_DIR}/cycle_a.db' AS cyc;
+----
+redirect
+
+# creating a pointer over an existing file requires overwrite
+statement error
+CALL redirect_create('{TEST_DIR}/redirect_ptr.db', 'redirect_real.db');
+----
+
+statement ok
+CALL redirect_create('{TEST_DIR}/redirect_ptr.db', 'redirect_real.db', overwrite => true);

--- a/test/sql/attach/attach_redirect.test
+++ b/test/sql/attach/attach_redirect.test
@@ -45,20 +45,15 @@ SELECT count(*) FROM ptr2.t;
 statement ok
 DETACH ptr2;
 
-# a chained redirect (pointer -> pointer -> real) resolves through the chain
+# chained redirects are not supported (0-or-1 rule): a pointer whose target is itself a pointer is rejected,
+# which also makes cycles impossible. redirect_ptr.db is itself a pointer, so redirecting to it is refused.
 statement ok
 CALL redirect_create('{TEST_DIR}/redirect_chain.db', 'redirect_ptr.db');
 
-statement ok
+statement error
 ATTACH '{TEST_DIR}/redirect_chain.db' AS chained;
-
-query I
-SELECT count(*) FROM chained.t;
 ----
-2
-
-statement ok
-DETACH chained;
+<REGEX>:.*chained redirects are not supported.*
 
 # an explicit TYPE duckdb bypasses redirect detection, but the storage open path refuses to open a pointer
 # file as an ordinary database - otherwise a write could clobber it and orphan the real target's data.
@@ -67,7 +62,7 @@ ATTACH '{TEST_DIR}/redirect_ptr.db' AS raw (TYPE duckdb);
 ----
 <REGEX>:.*redirect pointer file.*
 
-# a redirect cycle is detected and rejected rather than looping forever
+# a would-be cycle (a -> b -> a) cannot loop: the no-chain rule rejects it at the first hop, since b is a pointer
 statement ok
 CALL redirect_create('{TEST_DIR}/cycle_a.db', 'cycle_b.db');
 
@@ -77,7 +72,7 @@ CALL redirect_create('{TEST_DIR}/cycle_b.db', 'cycle_a.db');
 statement error
 ATTACH '{TEST_DIR}/cycle_a.db' AS cyc;
 ----
-redirect
+<REGEX>:.*chained redirects are not supported.*
 
 # creating a pointer over an existing file requires overwrite
 statement error

--- a/test/sql/attach/attach_redirect.test
+++ b/test/sql/attach/attach_redirect.test
@@ -92,3 +92,14 @@ CALL redirect_create('{TEST_DIR}/redirect_ptr.db', 'redirect_real.db');
 
 statement ok
 CALL redirect_create('{TEST_DIR}/redirect_ptr.db', 'redirect_real.db', overwrite => true);
+
+# a redirect to an extension storage type is routed to that type's extension resolution (proving the redirect
+# rewrote the db_type) rather than silently opening the pointer as an empty duckdb database. Using an unknown
+# type keeps this deterministic offline: it fails on extension resolution instead of attaching an empty db.
+statement ok
+CALL redirect_create('{TEST_DIR}/ext_ptr.db', 'some_target', type := 'not_a_real_db_type');
+
+statement error
+ATTACH '{TEST_DIR}/ext_ptr.db' AS extdb;
+----
+not_a_real_db_type

--- a/test/sql/attach/attach_redirect.test
+++ b/test/sql/attach/attach_redirect.test
@@ -145,3 +145,21 @@ statement error
 CALL redirect_create('{TEST_DIR}/old_ptr.db', 'redirect_real.db', storage_version => 'v1.4.0');
 ----
 <REGEX>:.*v2.0.0 or newer.*
+
+# #7: a redirected attach records the pointer file it came from in the `pointed_from` tag; the `path` column
+# shows the resolved target, the tag shows the pointer.
+statement ok
+ATTACH '{TEST_DIR}/redirect_ptr.db' AS ptrtag;
+
+query I
+SELECT tags['pointed_from'] LIKE '%redirect_ptr.db' FROM duckdb_databases WHERE database_name = 'ptrtag';
+----
+true
+
+query I
+SELECT path LIKE '%redirect_real.db' FROM duckdb_databases WHERE database_name = 'ptrtag';
+----
+true
+
+statement ok
+DETACH ptrtag;

--- a/test/sql/attach/attach_redirect.test
+++ b/test/sql/attach/attach_redirect.test
@@ -60,18 +60,12 @@ SELECT count(*) FROM chained.t;
 statement ok
 DETACH chained;
 
-# an explicit TYPE on the ATTACH short-circuits redirect interpretation: the raw pointer file opens as an
-# ordinary (empty) duckdb database, proving the redirect was not applied.
-statement ok
+# an explicit TYPE duckdb bypasses redirect detection, but the storage open path refuses to open a pointer
+# file as an ordinary database - otherwise a write could clobber it and orphan the real target's data.
+statement error
 ATTACH '{TEST_DIR}/redirect_ptr.db' AS raw (TYPE duckdb);
-
-query I
-SELECT count(*) FROM duckdb_tables() WHERE database_name = 'raw';
 ----
-0
-
-statement ok
-DETACH raw;
+<REGEX>:.*redirect pointer file.*
 
 # a redirect cycle is detected and rejected rather than looping forever
 statement ok
@@ -103,3 +97,24 @@ statement error
 ATTACH '{TEST_DIR}/ext_ptr.db' AS extdb;
 ----
 not_a_real_db_type
+
+# F1: the duplicate-open guard sees through a redirect. redirect_ptr.db points at redirect_real.db, so attaching
+# the real database directly and again via the pointer must conflict - otherwise two block managers could
+# checkpoint over each other and silently lose writes.
+statement ok
+ATTACH '{TEST_DIR}/redirect_real.db' AS direct;
+
+statement error
+ATTACH '{TEST_DIR}/redirect_ptr.db' AS via_ptr;
+----
+<REGEX>:.*conflict.*
+
+statement ok
+DETACH direct;
+
+# overwrite must refuse to clobber a real database - only a redirect pointer file may be replaced. Otherwise a
+# stray path typo would stamp a pointer header over a real database and orphan its data.
+statement error
+CALL redirect_create('{TEST_DIR}/redirect_real.db', 'somewhere', overwrite => true);
+----
+<REGEX>:.*not a redirect pointer.*

--- a/test/sql/attach/attach_redirect.test
+++ b/test/sql/attach/attach_redirect.test
@@ -15,10 +15,10 @@ INSERT INTO realdb.t VALUES (42), (43);
 statement ok
 DETACH realdb;
 
-# create a pointer file that redirects to the real database. A relative target is resolved against the
-# directory of the pointer file, so a bare filename points at a sibling database.
+# create a pointer file that redirects to the real database. A relative target given via `path` is resolved
+# against the directory of the pointer file, so a bare filename points at a sibling database.
 statement ok
-CALL redirect_create('{TEST_DIR}/redirect_ptr.db', 'redirect_real.db');
+CALL redirect_create('{TEST_DIR}/redirect_ptr.db', path := 'redirect_real.db');
 
 # attaching the pointer is reinterpreted to open the real database
 statement ok
@@ -45,10 +45,38 @@ SELECT count(*) FROM ptr2.t;
 statement ok
 DETACH ptr2;
 
+# overload A: create a pointer by capturing a currently-attached database by name. The pointer inherits the
+# database's resolved path, so attaching it reopens the same target.
+statement ok
+ATTACH '{TEST_DIR}/redirect_real.db' AS src;
+
+statement ok
+CALL redirect_create('{TEST_DIR}/from_db_ptr.db', 'src');
+
+statement ok
+DETACH src;
+
+statement ok
+ATTACH '{TEST_DIR}/from_db_ptr.db' AS fromdb;
+
+query I
+SELECT count(*) FROM fromdb.t;
+----
+2
+
+statement ok
+DETACH fromdb;
+
+# overload A throws if the named database is not attached
+statement error
+CALL redirect_create('{TEST_DIR}/nope_ptr.db', 'not_attached_db');
+----
+<REGEX>:.*is not attached.*
+
 # chained redirects are not supported (0-or-1 rule): a pointer whose target is itself a pointer is rejected,
 # which also makes cycles impossible. redirect_ptr.db is itself a pointer, so redirecting to it is refused.
 statement ok
-CALL redirect_create('{TEST_DIR}/redirect_chain.db', 'redirect_ptr.db');
+CALL redirect_create('{TEST_DIR}/redirect_chain.db', path := 'redirect_ptr.db');
 
 statement error
 ATTACH '{TEST_DIR}/redirect_chain.db' AS chained;
@@ -64,10 +92,10 @@ ATTACH '{TEST_DIR}/redirect_ptr.db' AS raw (TYPE duckdb);
 
 # a would-be cycle (a -> b -> a) cannot loop: the no-chain rule rejects it at the first hop, since b is a pointer
 statement ok
-CALL redirect_create('{TEST_DIR}/cycle_a.db', 'cycle_b.db');
+CALL redirect_create('{TEST_DIR}/cycle_a.db', path := 'cycle_b.db');
 
 statement ok
-CALL redirect_create('{TEST_DIR}/cycle_b.db', 'cycle_a.db');
+CALL redirect_create('{TEST_DIR}/cycle_b.db', path := 'cycle_a.db');
 
 statement error
 ATTACH '{TEST_DIR}/cycle_a.db' AS cyc;
@@ -76,17 +104,17 @@ ATTACH '{TEST_DIR}/cycle_a.db' AS cyc;
 
 # creating a pointer over an existing file requires overwrite
 statement error
-CALL redirect_create('{TEST_DIR}/redirect_ptr.db', 'redirect_real.db');
+CALL redirect_create('{TEST_DIR}/redirect_ptr.db', path := 'redirect_real.db');
 ----
 
 statement ok
-CALL redirect_create('{TEST_DIR}/redirect_ptr.db', 'redirect_real.db', overwrite => true);
+CALL redirect_create('{TEST_DIR}/redirect_ptr.db', path := 'redirect_real.db', overwrite => true);
 
 # a redirect to an extension storage type is routed to that type's extension resolution (proving the redirect
 # rewrote the db_type) rather than silently opening the pointer as an empty duckdb database. Using an unknown
 # type keeps this deterministic offline: it fails on extension resolution instead of attaching an empty db.
 statement ok
-CALL redirect_create('{TEST_DIR}/ext_ptr.db', 'some_target', type := 'not_a_real_db_type');
+CALL redirect_create('{TEST_DIR}/ext_ptr.db', path := 'some_target', type := 'not_a_real_db_type');
 
 statement error
 ATTACH '{TEST_DIR}/ext_ptr.db' AS extdb;
@@ -110,14 +138,14 @@ DETACH direct;
 # overwrite must refuse to clobber a real database - only a redirect pointer file may be replaced. Otherwise a
 # stray path typo would stamp a pointer header over a real database and orphan its data.
 statement error
-CALL redirect_create('{TEST_DIR}/redirect_real.db', 'somewhere', overwrite => true);
+CALL redirect_create('{TEST_DIR}/redirect_real.db', path := 'somewhere', overwrite => true);
 ----
 <REGEX>:.*not a redirect pointer.*
 
 # F4: a core-consumed option (read_only) stored in a pointer is applied to the reinterpreted attach, not rejected
 # as an unknown option. The pointer opens its target read-only.
 statement ok
-CALL redirect_create('{TEST_DIR}/ro_ptr.db', 'redirect_real.db', options => MAP {'read_only': 'true'});
+CALL redirect_create('{TEST_DIR}/ro_ptr.db', path := 'redirect_real.db', attach_options => MAP {'read_only': 'true'});
 
 statement ok
 ATTACH '{TEST_DIR}/ro_ptr.db' AS rodb;
@@ -137,7 +165,7 @@ DETACH rodb;
 
 # a storage version below v2.0.0 is refused for a pointer file (older DuckDB must reject it, not open it empty)
 statement error
-CALL redirect_create('{TEST_DIR}/old_ptr.db', 'redirect_real.db', storage_version => 'v1.4.0');
+CALL redirect_create('{TEST_DIR}/old_ptr.db', path := 'redirect_real.db', storage_version => 'v1.4.0');
 ----
 <REGEX>:.*v2.0.0 or newer.*
 


### PR DESCRIPTION
Idea is as follow:
```sql
ATTACH 'some_database.db' AS my_db (STORAGE_VERSION 'v1.5.0');
CREATE TABLE my_db.T AS (SELECT 'hi' AS greeting FROM range(10));
CALL redirect_create ('some_other_database.db', 'my_db');
````
now there are 2 files:
```
-rw-r--r--  1 carlo  staff  536576 Aug 18 10:59 some_database.db
-rw-r--r--  1 carlo  staff   12288 Aug 18 10:59 some_other_database.db
```

Both are valid duckdb databases, with the second one being essentially a link to the first one.

```
build/release/duckdb some_database.db
build/release/duckdb some_other_database.db
```
basically work now in the same way (but for `FROM duckdb_databases()` that will inform one is being accessed via a redirect, see `tag` column)

This can be more interesting for allowing uniform access to databases, possibly via:
```sql
CREATE SECRET ...
ATTACH 's3://my-company-bucket/analytics.db' AS db;
```
where `analytics.db` could be either a duckdb file, or a pointer to some other database (think a specific postgres instance, or a ducklake instance, or a iceberg one, or a quack live instance, or whatever is attachable from duckdb).

I think  this can be very interesting combined with both ducklake AND quack, say at rest the file repoints to the actual data (as a static duckdb file elsewhere), but IF quack server is up then the pointer/redirect can be moved to point to an actual quack instance.

Note that credentials needs either to be embedded in the ATTACH options (not recommended, and available only in some cases) or the user still need to have credentials (both to the redirect AND to the actual redirected to databases).

Some ideas that allows this to work / keep surface limited:
* supported in 2.0.0 onward (so tied to v2.0.0 release)
* ergonomics of `redirect_create` are not great, for now only table function, but important path is in my mind the format
* limited to single hop (cuts on cycle detection and seems reasonable in general, can be lifted later but I would stay with 0 or 1 hop)
* 1st header stores whether it's a redirect database, then stored in 2nd or 3rd header, allowing atomic rewrite
* combines with encryption